### PR TITLE
feat: Rebuild `enabledmods.json` if value not found

### DIFF
--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -46,7 +46,19 @@ pub fn set_mod_enabled_status(
     let enabledmods_json_path = format!("{}/R2Northstar/enabledmods.json", game_install.game_path);
 
     // Parse JSON
-    let mut res: serde_json::Value = get_enabled_mods(game_install.clone())?;
+    let mut res: serde_json::Value = match get_enabled_mods(game_install.clone()) {
+        Ok(res) => res,
+        Err(err) => {
+            println!("Couldn't parse `enabledmod.json`: {}", err);
+            println!("Rebuilding file.");
+
+            rebuild_enabled_mods_json(game_install.clone())?;
+
+            // Then try again
+            let res = get_enabled_mods(game_install.clone())?;
+            res
+        }
+    };
 
     // Check if key exists
     if res.get(mod_name.clone()).is_none() {

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -27,7 +27,6 @@ pub fn rebuild_enabled_mods_json(game_install: GameInstall) -> Result<(), String
     let obj = serde_json::Value::Object(my_map);
 
     // Write to file
-    println!("{}", serde_json::to_string_pretty(&obj).unwrap());
     std::fs::write(
         enabledmods_json_path,
         serde_json::to_string_pretty(&obj).unwrap(),


### PR DESCRIPTION
When toggling a mod on enabled mods that is not present in `enabledmods.json` we would previously just error out. Now we rebuild the `enabledmods.json` file in a Northstar compatible format and then toggle the mod in question.


This means no more
![image](https://user-images.githubusercontent.com/40122905/204002177-c6a9eb78-68cd-4740-82fc-d8e33e6ba906.png)

:D


Also, nice PR number :3