### PR TITLE
refactor: Define core mods in global const

### DIFF
--- a/src-tauri/src/northstar/mod.rs
+++ b/src-tauri/src/northstar/mod.rs
@@ -1,6 +1,12 @@
 //! This module deals with handling things around Northstar such as
 //! - getting version number
 
+pub const CORE_MODS: [&str; 3] = [
+    "Northstar.Client",
+    "Northstar.Custom",
+    "Northstar.CustomServers",
+];
+
 use crate::check_mod_version_number;
 use anyhow::anyhow;
 
@@ -12,20 +18,15 @@ pub fn get_northstar_version_number(game_path: String) -> Result<String, anyhow:
     // TODO:
     // Check if NorthstarLauncher.exe exists and check its version number
     let profile_folder = "R2Northstar";
-    let core_mods = [
-        "Northstar.Client",
-        "Northstar.Custom",
-        "Northstar.CustomServers",
-    ];
     let initial_version_number = match check_mod_version_number(format!(
         "{}/{}/mods/{}",
-        game_path, profile_folder, core_mods[0]
+        game_path, profile_folder, CORE_MODS[0]
     )) {
         Ok(version_number) => version_number,
         Err(err) => return Err(err),
     };
 
-    for core_mod in core_mods {
+    for core_mod in CORE_MODS {
         let current_version_number = match check_mod_version_number(format!(
             "{}/{}/mods/{}",
             game_path, profile_folder, core_mod

--- a/src-tauri/src/repair_and_verify/mod.rs
+++ b/src-tauri/src/repair_and_verify/mod.rs
@@ -1,7 +1,7 @@
 /// Contains various functions to repair common issues and verifying installation
 
 use app::{get_enabled_mods, GameInstall};
-use crate::mod_management::set_mod_enabled_status;
+use crate::{mod_management::set_mod_enabled_status, northstar::CORE_MODS};
 use anyhow::anyhow;
 
 /// Verifies Titanfall2 game files
@@ -15,17 +15,10 @@ pub fn verify_game_files(game_install: GameInstall) -> Result<String, String> {
 pub fn disable_all_but_core(game_install: GameInstall) -> Result<(), String> {
     let current_mods = get_enabled_mods(game_install.clone())?;
 
-    // These are the mods we do not want to disable
-    let core_mods = [
-        "Northstar.Client",
-        "Northstar.Custom",
-        "Northstar.CustomServers",
-    ];
-    // let sub_values: Vec<HashMap<String, Value>> = serde_json::from_str(&json)?;
-
+    // Disable all mods, set core mods to enabled
     for (key, _value) in current_mods.as_object().unwrap() {
-        if core_mods.contains(&key.as_str()) {
-            // This is a core mod
+        if CORE_MODS.contains(&key.as_str()) {
+            // This is a core mod, we do not want to disable it
             set_mod_enabled_status(game_install.clone(), key.to_string(), true)?;
         } else {
             // Not a core mod


### PR DESCRIPTION
This way we only define them in one place which makes adding/removing core mods (e.g. `Northstar.Coop`) easier in the future.