### PR TITLE
docs: General cleanup

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,6 +33,8 @@ Then for developing
 npx tauri dev
 ```
 
+Automatic recompiling on save is enabled for both the Rust and the Typescript/Vue code.
+
 ## Tauri
 
 An introduction to Tauri can be seen in this short YouTube video: https://youtu.be/-X8evddpu7M

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -152,10 +152,6 @@ else {
 
 ```
 
-## Building
-
-Release builds are generally done via CI. To build locally, make sure typescript is compiled (`./node_modules/.bin/rollup --config`), then run `npm run tauri build`.
-
 ## Other
 
 This repo uses [EditorConfig](https://editorconfig.org/) to define some basic formatting rules. Find a plugin for your IDE [here](https://editorconfig.org/#download).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development
 
-FlightCore uses [Tauri](https://tauri.app/) as its UI framework. This means it is split into a **backend** written in [Rust](https://www.rust-lang.org/) and a frontend written in [Vue](https://vuejs.org/) and [TypeScript](https://www.typescriptlang.org/).
+FlightCore uses [Tauri](https://tauri.app/) as its UI framework. This means it is split into a **backend** written in [Rust](https://www.rust-lang.org/) and a **frontend** written in [Vue](https://vuejs.org/) and [TypeScript](https://www.typescriptlang.org/).
 
 ## Design goals
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,10 +12,10 @@ As for splitting logic between _frontend_ and _backend_, state and UI related lo
 
 ## Setup
 
-Make sure you have the necessary dependencies installed: https://tauri.app/v1/guides/getting-started/prerequisites
+Make sure you have the necessary dependencies for Tauri installed as described in this link: https://tauri.app/v1/guides/getting-started/prerequisites
 
 
-Install `npm` dependencies with 
+Then, install `npm` dependencies with
 
 ```sh
 npm install


### PR DESCRIPTION
- Remove obsolete section mentioning how to compile Typescript code (no longer applies)
- Add note about auto-recompile
- Attempt to improve setup instructions