### PR TITLE
refactor: Remove the "Origin running" check from frontend

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -241,6 +241,21 @@ pub fn launch_northstar(
 ) -> Result<String, String> {
     dbg!(game_install.clone());
 
+    let host_os = get_host_os();
+
+    // Explicitly fail early certain (currently) unsupported install setups
+    if host_os != "windows"
+        || !(matches!(game_install.install_type, InstallType::STEAM)
+            || matches!(game_install.install_type, InstallType::ORIGIN)
+            || matches!(game_install.install_type, InstallType::UNKNOWN))
+    {
+        return Err(format!(
+            "Not yet implemented for \"{}\" with Titanfall2 installed via \"{:?}\"",
+            get_host_os(),
+            game_install.install_type
+        ));
+    }
+
     let bypass_checks = match bypass_checks {
         Some(bypass_checks) => bypass_checks,
         None => false,
@@ -260,21 +275,6 @@ pub fn launch_northstar(
                 anyhow!("Origin not running, start Origin before launching Northstar").to_string(),
             );
         }
-    }
-
-    let host_os = get_host_os();
-
-    // Explicetly fail early certain (currently) unsupported install setups
-    if host_os != "windows"
-        || !(matches!(game_install.install_type, InstallType::STEAM)
-            || matches!(game_install.install_type, InstallType::ORIGIN)
-            || matches!(game_install.install_type, InstallType::UNKNOWN))
-    {
-        return Err(format!(
-            "Not yet implemented for \"{}\" with Titanfall2 installed via \"{:?}\"",
-            get_host_os(),
-            game_install.install_type
-        ));
     }
 
     // Switch to Titanfall2 directory for launching

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -199,7 +199,12 @@ export const store = createStore<FlightCoreStore>({
                         })
                         .catch((error) => {
                             console.error(error);
-                            alert(error);
+                            ElNotification({
+                                title: 'Error',
+                                message: error,
+                                type: 'error',
+                                position: 'bottom-right'
+                            });
                         });
                     break;
 

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -192,18 +192,6 @@ export const store = createStore<FlightCoreStore>({
 
                 // Game is ready to play.
                 case NorthstarState.READY_TO_PLAY:
-                    // Show an error message if Origin is not running.
-                    if (!state.origin_is_running) {
-                        ElNotification({
-                            title: 'Origin is not running',
-                            message: "Northstar cannot launch while you're not authenticated with Origin.",
-                            type: 'warning',
-                            position: 'bottom-right'
-                        });
-
-                        // If Origin isn't running, end here
-                        return;
-                    }
                     await invoke("launch_northstar_caller", { gameInstall: game_install })
                         .then((message) => {
                             console.log(message);


### PR DESCRIPTION
We perform the check twice (both frontend and backend), however the frontend doesn't check for OS, meaning on Linux it will always error out with "Origin not running".

So instead we should just do the check only in backend and propagate the right error message to frontend.