### PR TITLE
fix: Do not crash on Origin install find failure

### DIFF
--- a/src-tauri/src/platform_specific/windows.rs
+++ b/src-tauri/src/platform_specific/windows.rs
@@ -20,7 +20,9 @@ pub fn origin_install_location_detection() -> Result<String, anyhow::Error> {
     let output = ps.run(r#"Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Respawn\Titanfall2\ -Name "Install Dir""#).unwrap();
 
     // Get command output as string
-    let string = output.stdout()?;
+    let string = output
+        .stdout()
+        .ok_or(anyhow!("Couldn't get PowerShell output"))?;
 
     // Regex the result out and return value accordingly
     let regex = Regex::new(r"(?m)Install Dir.+: (.+)\r\n")?;

--- a/src-tauri/src/platform_specific/windows.rs
+++ b/src-tauri/src/platform_specific/windows.rs
@@ -20,10 +20,10 @@ pub fn origin_install_location_detection() -> Result<String, anyhow::Error> {
     let output = ps.run(r#"Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Respawn\Titanfall2\ -Name "Install Dir""#).unwrap();
 
     // Get command output as string
-    let string = output.stdout().unwrap();
+    let string = output.stdout()?;
 
     // Regex the result out and return value accordingly
-    let regex = Regex::new(r"(?m)Install Dir.+: (.+)\r\n").unwrap();
+    let regex = Regex::new(r"(?m)Install Dir.+: (.+)\r\n")?;
     let mut result = regex.captures_iter(&string);
     match result.next() {
         Some(mat) => {


### PR DESCRIPTION
The unwraps would cause the thread to crash in case FlightCore is unable to use Powershell output to find Origin Titanfall2 install path. Instead we just return the error message which is caught and handled by the parent function.