### PR TITLE
fix: Make sure all non-core mods get disabled

### DIFF
--- a/src-tauri/src/repair_and_verify/mod.rs
+++ b/src-tauri/src/repair_and_verify/mod.rs
@@ -1,4 +1,4 @@
-use crate::{mod_management::set_mod_enabled_status, northstar::CORE_MODS};
+use crate::{mod_management::{set_mod_enabled_status, rebuild_enabled_mods_json}, northstar::CORE_MODS};
 use anyhow::anyhow;
 /// Contains various functions to repair common issues and verifying installation
 use app::{get_enabled_mods, GameInstall};
@@ -12,6 +12,10 @@ pub fn verify_game_files(game_install: GameInstall) -> Result<String, String> {
 /// Disables all mods except core ones
 /// Enables core mods if disabled
 pub fn disable_all_but_core(game_install: GameInstall) -> Result<(), String> {
+
+    // Rebuild `enabledmods.json` first to ensure all mods are added
+    rebuild_enabled_mods_json(game_install.clone())?;
+
     let current_mods = get_enabled_mods(game_install.clone())?;
 
     // Disable all mods, set core mods to enabled


### PR DESCRIPTION
For this we first rebuild the `enabledmods.json` file. This ensures that all installed mods are actually listed there.

The function was originally created before we could rebuild `enabledmods.json` by checking installed mods.