### PR TITLE
chore: Bump Rust version to 1.65

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ license = ""
 repository = ""
 default-run = "app"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Should resolve https://github.com/R2NorthstarTools/FlightCore/pull/85#issuecomment-1336846037

Technically `1.64` would be enough to solve that issue but[ `1.65` adds let-else statements to stable which allow for more compact and readable code in some cases](https://www.youtube.com/watch?v=U-5_bumwH9w). ^^