### PR TITLE
feat: Expose installed NS mod directory

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,7 @@ pub struct NorthstarMod {
     pub name: String,
     pub thunderstore_mod_string: Option<String>,
     pub enabled: bool,
+    pub directory: String,
 }
 
 /// Check version number of a mod

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -128,13 +128,13 @@ fn parse_mod_json_for_thunderstore_mod_string(
 /// Parse `mods` folder for installed mods.
 fn parse_installed_mods(
     game_install: GameInstall,
-) -> Result<Vec<(String, Option<String>)>, String> {
+) -> Result<Vec<(String, Option<String>, String)>, String> {
     let ns_mods_folder = format!("{}/R2Northstar/mods/", game_install.game_path);
 
     let paths = std::fs::read_dir(ns_mods_folder).unwrap();
 
     let mut directories: Vec<PathBuf> = Vec::new();
-    let mut mods: Vec<(String, Option<String>)> = Vec::new();
+    let mut mods: Vec<(String, Option<String>, String)> = Vec::new();
 
     // Get list of folders in `mods` directory
     for path in paths {
@@ -167,8 +167,10 @@ fn parse_installed_mods(
                 Ok(thunderstore_mod_string) => Some(thunderstore_mod_string),
                 Err(_err) => None,
             };
+        // Get directory path
+        let mod_directory = directory.to_str().unwrap().to_string();
 
-        mods.push((mod_name, thunderstore_mod_string));
+        mods.push((mod_name, thunderstore_mod_string, mod_directory));
     }
 
     // Return found mod names
@@ -194,7 +196,7 @@ pub fn get_installed_mods_and_properties(
     let mapping = enabled_mods.as_object().unwrap();
 
     // Use list of installed mods and set enabled based on `enabledmods.json`
-    for (name, thunderstore_mod_string) in found_installed_mods {
+    for (name, thunderstore_mod_string, mod_directory) in found_installed_mods {
         let current_mod_enabled = match mapping.get(&name) {
             Some(enabled) => enabled.as_bool().unwrap(),
             None => true, // Northstar considers mods not in mapping as enabled.
@@ -203,6 +205,7 @@ pub fn get_installed_mods_and_properties(
             name: name,
             thunderstore_mod_string: thunderstore_mod_string,
             enabled: current_mod_enabled,
+            directory: mod_directory,
         };
         installed_mods.push(current_mod);
     }

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -126,15 +126,13 @@ fn parse_mod_json_for_thunderstore_mod_string(
 }
 
 /// Parse `mods` folder for installed mods.
-fn parse_installed_mods(
-    game_install: GameInstall,
-) -> Result<Vec<(String, Option<String>, String)>, String> {
+fn parse_installed_mods(game_install: GameInstall) -> Result<Vec<NorthstarMod>, String> {
     let ns_mods_folder = format!("{}/R2Northstar/mods/", game_install.game_path);
 
     let paths = std::fs::read_dir(ns_mods_folder).unwrap();
 
     let mut directories: Vec<PathBuf> = Vec::new();
-    let mut mods: Vec<(String, Option<String>, String)> = Vec::new();
+    let mut mods: Vec<NorthstarMod> = Vec::new();
 
     // Get list of folders in `mods` directory
     for path in paths {
@@ -170,7 +168,14 @@ fn parse_installed_mods(
         // Get directory path
         let mod_directory = directory.to_str().unwrap().to_string();
 
-        mods.push((mod_name, thunderstore_mod_string, mod_directory));
+        let ns_mod = NorthstarMod {
+            name: mod_name,
+            thunderstore_mod_string: thunderstore_mod_string,
+            enabled: false, // Placeholder
+            directory: mod_directory,
+        };
+
+        mods.push(ns_mod);
     }
 
     // Return found mod names
@@ -196,17 +201,12 @@ pub fn get_installed_mods_and_properties(
     let mapping = enabled_mods.as_object().unwrap();
 
     // Use list of installed mods and set enabled based on `enabledmods.json`
-    for (name, thunderstore_mod_string, mod_directory) in found_installed_mods {
-        let current_mod_enabled = match mapping.get(&name) {
+    for mut current_mod in found_installed_mods {
+        let current_mod_enabled = match mapping.get(&current_mod.name) {
             Some(enabled) => enabled.as_bool().unwrap(),
             None => true, // Northstar considers mods not in mapping as enabled.
         };
-        let current_mod: NorthstarMod = NorthstarMod {
-            name: name,
-            thunderstore_mod_string: thunderstore_mod_string,
-            enabled: current_mod_enabled,
-            directory: mod_directory,
-        };
+        current_mod.enabled = current_mod_enabled;
         installed_mods.push(current_mod);
     }
 

--- a/src-vue/src/utils/NorthstarMod.d.ts
+++ b/src-vue/src/utils/NorthstarMod.d.ts
@@ -3,4 +3,5 @@ export interface NorthstarMod {
     name: string,
     thunderstore_mod_string?: string,
     enabled: bool,
+    directory: string,
 }


### PR DESCRIPTION
This allows other functions to get a mod directory directly which is useful for e.g. deleting a mod.