### PR TITLE
fix: Mod view with no game install

### DIFF
--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -238,6 +238,13 @@ export const store = createStore<FlightCoreStore>({
                 game_path: state.game_path,
                 install_type: state.install_type
             } as GameInstall;
+
+            // If there's no game path, prevent looking for installed mods.
+            if (state.game_path === undefined) {
+                console.warn('Cannot load installed mods since so game path is selected.');
+                return;
+            }
+
             // Call back-end for installed mods
             await invoke("get_installed_mods_caller", { gameInstall: game_install })
                 .then((message) => {

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -245,16 +245,12 @@ export const store = createStore<FlightCoreStore>({
                 })
                 .catch((error) => {
                     console.error(error);
-                    // TODO discuss if we should delete this
-                    // If there's no other error case as "no install selected", I think we can get rid of it.
-                    /*
                     ElNotification({
                         title: 'Error',
                         message: error,
                         type: 'error',
                         position: 'bottom-right'
                     });
-                    */
                 });
         },
         async toggleReleaseCandidate(state: FlightCoreStore) {

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -245,12 +245,16 @@ export const store = createStore<FlightCoreStore>({
                 })
                 .catch((error) => {
                     console.error(error);
+                    // TODO discuss if we should delete this
+                    // If there's no other error case as "no install selected", I think we can get rid of it.
+                    /*
                     ElNotification({
                         title: 'Error',
                         message: error,
                         type: 'error',
                         position: 'bottom-right'
                     });
+                    */
                 });
         },
         async toggleReleaseCandidate(state: FlightCoreStore) {

--- a/src-vue/src/views/ModsView.vue
+++ b/src-vue/src/views/ModsView.vue
@@ -3,7 +3,8 @@
         <el-scrollbar>
             <h3>Installed Mods:</h3>
             <div>
-                <el-card shadow="hover" v-for="mod in installedMods" v-bind:key="mod.name">
+                <p v-if="installedMods.length === 0">No mods were found.</p>
+                <el-card v-else shadow="hover" v-for="mod in installedMods" v-bind:key="mod.name">
                     <el-switch style="--el-switch-on-color: #13ce66; --el-switch-off-color: #8957e5" v-model="mod.enabled"
                         :before-change="() => updateWhichModsEnabled(mod)" :loading="global_load_indicator" />
                     {{mod.name}}

--- a/src-vue/src/views/ModsView.vue
+++ b/src-vue/src/views/ModsView.vue
@@ -3,7 +3,7 @@
         <el-scrollbar>
             <h3>Installed Mods:</h3>
             <div>
-                <el-card shadow="hover" v-for="mod in $store.state.installed_mods">
+                <el-card shadow="hover" v-for="mod in installedMods" v-bind:key="mod.name">
                     <el-switch style="--el-switch-on-color: #13ce66; --el-switch-off-color: #8957e5" v-model="mod.enabled"
                         :before-change="() => updateWhichModsEnabled(mod)" :loading="global_load_indicator" />
                     {{mod.name}}
@@ -29,6 +29,11 @@ export default defineComponent({
     },
     async mounted() {
         this.$store.commit('loadInstalledMods');
+    },
+    computed: {
+        installedMods(): NorthstarMod[] {
+            return this.$store.state.installed_mods;
+        }
     },
     methods: {
         async updateWhichModsEnabled(mod: NorthstarMod) {


### PR DESCRIPTION
Display a message on empty mods view instead of showing an error notification.
Closes #64.

##### Before

![Capture d’écran de 2022-12-15 08-25-10](https://user-images.githubusercontent.com/11993538/207798629-a2e7d90f-a19a-4dc3-a1e7-916ff103b0ea.png)

##### After

![Capture d’écran de 2022-12-15 08-23-40](https://user-images.githubusercontent.com/11993538/207798329-83076327-a6cb-4751-aeed-7ed9086aa351.png)
