### PR TITLE
feat: Alternatively check if EA App is running

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -311,6 +311,12 @@ pub fn check_origin_running() -> bool {
     for _process in s.processes_by_name("Origin.exe") {
         // check here if this is your process
         // dbg!(process);
+        // There's at least one Origin process, so we can launch
+        return true;
+    }
+    // Alternatively, check for EA Desktop
+    for _process in s.processes_by_name("EADesktop.exe") {
+        // There's at least one EADesktop process, so we can launch
         return true;
     }
     false


### PR DESCRIPTION
With EA switching from Origin to EA App, we need to check for that instead.

Longterm, we should just launch via Steam and/or EA App directly, passing `-norhtstar` in the process to get it to launch Northstar instead.