### PR TITLE
build: Cache Rust build artifacts

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -45,6 +45,9 @@ jobs:
         rm src-tauri/tauri.conf.json
         mv src-tauri/tauri.conf.json.new src-tauri/tauri.conf.json
     - uses: Swatinem/rust-cache@v2 # Cache Rust build artifacts
+      with:
+        workspaces: |
+          src-tauri
     - name: install app dependencies and build it
       env:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -44,6 +44,7 @@ jobs:
         jq '.tauri.updater.active = false' src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.new
         rm src-tauri/tauri.conf.json
         mv src-tauri/tauri.conf.json.new src-tauri/tauri.conf.json
+    - uses: Swatinem/rust-cache@v2 # Cache Rust build artifacts
     - name: install app dependencies and build it
       env:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+    - uses: Swatinem/rust-cache@v2 # Cache Rust build artifacts
     - name: install app dependencies and build it
       env:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
     - uses: Swatinem/rust-cache@v2 # Cache Rust build artifacts
+      with:
+        workspaces: |
+          src-tauri
     - name: install app dependencies and build it
       env:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
     windows_subsystem = "windows"
 )]
 
+
 use std::{
     env,
     sync::{Arc, Mutex},

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,7 +3,6 @@
     windows_subsystem = "windows"
 )]
 
-
 use std::{
     env,
     sync::{Arc, Mutex},


### PR DESCRIPTION
To reduce CI runtime by making use of cached artifacts