### PR TITLE
feat: Maximize button + clean menubar layout

### DIFF
--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -47,7 +47,9 @@ export default {
   <div class="app-inner">
     <div id="fc_bg__container" :style="bgStyle"/>
 
-    <el-menu
+    <nav id="fc_menu-bar">
+      <!-- Navigation items -->
+      <el-menu
         default-active="/"
         router
         mode="horizontal"
@@ -61,6 +63,7 @@ export default {
         <el-menu-item index="/settings">Settings</el-menu-item>
         <el-menu-item index="/dev" v-if="$store.state.developer_mode">Dev</el-menu-item>
     </el-menu>
+    </nav>
 
     <router-view></router-view>
 
@@ -107,12 +110,19 @@ export default {
   height: calc(100% - var(--fc-menu_height));
 }
 
+#fc_menu-bar {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: var(--fc-menu_height);
+}
+
 /* Header menu */
 #fc__menu_bar {
   background-image: radial-gradient(transparent 1px);
   backdrop-filter: saturate(50%) blur(4px);
   background-color: transparent;
-  height: var(--fc-menu_height);
+  height: 100%;
 }
 
 .developer_build {

--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -23,6 +23,9 @@ export default {
     store.commit('initialize');
   },
   methods: {
+    async toggleMaximize() {
+      await appWindow.toggleMaximize();
+    },
     minimize() {
       appWindow.minimize()
     },
@@ -63,6 +66,7 @@ export default {
 
     <div id="fc_window__controls">
         <el-button color="white" icon="SemiSelect" @click="minimize" circle />
+        <el-button color="white" icon="FullScreen" @click="toggleMaximize" circle />
         <el-button color="white" icon="CloseBold" @click="close" circle />
     </div>
   </div>

--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -104,8 +104,12 @@ export default {
   width: calc(100% - 148px); /* window controls container width */
 }
 
-#fc__menu_items .el-menu-item {
+#fc__menu_items .el-menu-item, #fc__menu_items .el-sub-menu__title {
   color: #b4b6b9;
+  border-color: white;
+}
+
+.el-menu > .el-menu-item {
   text-transform: uppercase;
   border: none !important;
   font-family: 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', '微软雅黑', Arial, sans-serif;
@@ -113,12 +117,12 @@ export default {
   font-size: large;
 }
 
-#fc__menu_items .el-menu-item:hover {
+#fc__menu_items .el-menu-item:hover, #fc__menu_items .el-sub-menu__title {
   color: #c6c9ce;
   background-color: transparent;
 }
 
-#fc__menu_items .el-menu-item.is-active, #fc__menu_items .el-menu-item:focus {
+#fc__menu_items .el-menu-item.is-active, #fc__menu_items .el-menu-item:focus, #fc__menu_items .el-sub-menu.is-active > .el-sub-menu__title {
   color: white !important;
   background-color: transparent;
 }

--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -53,7 +53,7 @@ export default {
         default-active="/"
         router
         mode="horizontal"
-        id="fc__menu_bar"
+        id="fc__menu_items"
         data-tauri-drag-region
     >
         <el-menu-item index="/">Play</el-menu-item>
@@ -76,8 +76,18 @@ export default {
 </template>
 
 <style>
+#fc_menu-bar {
+  position: fixed;
+  z-index: 1;
+  top: 0;
+  width: 100%;
+  height: var(--fc-menu_height);
+  background-image: radial-gradient(transparent 1px);
+  backdrop-filter: saturate(50%) blur(4px);
+}
+
 /* Borders reset */
-#fc__menu_bar {
+#fc__menu_bar, #fc__menu_items {
     border: none !important;
 }
 .app-inner {
@@ -86,7 +96,12 @@ export default {
 }
 
 /* Header item */
-#fc__menu_bar .el-menu-item {
+#fc__menu_items {
+  height: 100%;
+  background-color: transparent;
+}
+
+#fc__menu_items .el-menu-item {
   color: #b4b6b9;
   text-transform: uppercase;
   border: none !important;
@@ -95,12 +110,12 @@ export default {
   font-size: large;
 }
 
-#fc__menu_bar .el-menu-item:hover {
+#fc__menu_items .el-menu-item:hover {
   color: #c6c9ce;
   background-color: transparent;
 }
 
-#fc__menu_bar .el-menu-item.is-active, #fc__menu_bar .el-menu-item:focus {
+#fc__menu_items .el-menu-item.is-active, #fc__menu_items .el-menu-item:focus {
   color: white !important;
   background-color: transparent;
 }
@@ -110,21 +125,7 @@ export default {
   height: calc(100% - var(--fc-menu_height));
 }
 
-#fc_menu-bar {
-  position: fixed;
-  top: 0;
-  width: 100%;
-  height: var(--fc-menu_height);
-}
-
 /* Header menu */
-#fc__menu_bar {
-  background-image: radial-gradient(transparent 1px);
-  backdrop-filter: saturate(50%) blur(4px);
-  background-color: transparent;
-  height: 100%;
-}
-
 .developer_build {
   background: repeating-linear-gradient(
     45deg,

--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -115,6 +115,7 @@ export default {
   font-family: 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', '微软雅黑', Arial, sans-serif;
   font-weight: bold;
   font-size: large;
+  background-color: transparent !important;
 }
 
 #fc__menu_items .el-menu-item:hover, #fc__menu_items .el-sub-menu__title {
@@ -122,9 +123,8 @@ export default {
   background-color: transparent;
 }
 
-#fc__menu_items .el-menu-item.is-active, #fc__menu_items .el-menu-item:focus, #fc__menu_items .el-sub-menu.is-active > .el-sub-menu__title {
+#fc__menu_items .el-menu-item.is-active, #fc__menu_items .el-sub-menu.is-active > .el-sub-menu__title {
   color: white !important;
-  background-color: transparent;
 }
 
 .app-inner > .fc__mods__container {

--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -55,23 +55,24 @@ export default {
         mode="horizontal"
         id="fc__menu_items"
         data-tauri-drag-region
-    >
+      >
         <el-menu-item index="/">Play</el-menu-item>
         <el-menu-item index="/changelog">Changelog</el-menu-item>
         <el-menu-item index="/mods">Mods</el-menu-item>
         <el-menu-item index="/thunderstoreMods">Thunderstore</el-menu-item>
         <el-menu-item index="/settings">Settings</el-menu-item>
         <el-menu-item index="/dev" v-if="$store.state.developer_mode">Dev</el-menu-item>
-    </el-menu>
-    </nav>
+      </el-menu>
 
-    <router-view></router-view>
-
-    <div id="fc_window__controls">
+      <!-- Window controls -->
+      <div id="fc_window__controls">
         <el-button color="white" icon="SemiSelect" @click="minimize" circle />
         <el-button color="white" icon="FullScreen" @click="toggleMaximize" circle />
         <el-button color="white" icon="CloseBold" @click="close" circle />
-    </div>
+      </div>
+    </nav>
+
+    <router-view></router-view>
   </div>
 </template>
 
@@ -99,6 +100,8 @@ export default {
 #fc__menu_items {
   height: 100%;
   background-color: transparent;
+  float: left;
+  width: calc(100% - 148px); /* window controls container width */
 }
 
 #fc__menu_items .el-menu-item {
@@ -138,11 +141,8 @@ export default {
 
 /* Window controls */
 #fc_window__controls {
-  display: flex;
-  position: absolute;
-  top: 0;
-  right: 0;
-  height: var(--fc-menu_height);
+  float: right;
+  height: 100%;
 }
 
 #fc_window__controls > button {
@@ -151,6 +151,7 @@ export default {
   margin: auto 5px;
   background: none;
   border: none;
+  height: 100%;
 }
 
 #fc_window__controls > button:hover {

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -293,7 +293,8 @@ async function _initializeApp(state: any) {
         state.developer_mode = true;
 
         // Make menubar striped if debug build
-        let menu_bar_handle = document.querySelector('#fc__menu_bar');
+        let menu_bar_handle = document.querySelector('#fc_menu-bar');
+        console.log(menu_bar_handle);
         if (menu_bar_handle !== null) {
             menu_bar_handle.classList.toggle('developer_build');
         }

--- a/src-vue/src/style.css
+++ b/src-vue/src/style.css
@@ -37,6 +37,7 @@ body {
 
 .fc-container {
     position: relative;
+    margin-top: var(--fc-menu_height);
     height: calc(100% - var(--fc-menu_height));
     color: white;
 }

--- a/src-vue/src/style.css
+++ b/src-vue/src/style.css
@@ -37,7 +37,7 @@ body {
 
 .fc-container {
     position: relative;
-    margin-top: var(--fc-menu_height);
-    height: calc(100% - var(--fc-menu_height));
+    padding-top: var(--fc-menu_height);
+    height: 100%;
     color: white;
 }

--- a/src-vue/src/views/PlayView.vue
+++ b/src-vue/src/views/PlayView.vue
@@ -91,6 +91,7 @@ export default defineComponent({
     position: fixed;
     padding: 10px 20px;
     color: #e8edef;
+    bottom: 43px;
 }
 
 .fc_version__line {


### PR DESCRIPTION
This adds a new window control that enables user to maximize/minimize window.

It also restructures the menu bar, to properly display menu items when menu bar width reduces.

---

#### Screenshots

###### Maximizing (I couldn't capture entire screen, hence top screen cut, needed for me to be able to minimize window :) )

![Peek 22-12-2022 16-43](https://user-images.githubusercontent.com/11993538/209170891-1dfa29d3-73aa-49d0-b64f-15615b68f36e.gif)

###### Before

![Peek 22-12-2022 16-35](https://user-images.githubusercontent.com/11993538/209169273-b6d68367-1050-4818-9493-5e36f25a772c.gif)

###### After

![Peek 22-12-2022 16-33](https://user-images.githubusercontent.com/11993538/209169338-f223692b-082c-4c2f-b481-d876e522f142.gif)

