### PR TITLE
feat: Thunderstore mods pagination

### DIFF
--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -326,7 +326,7 @@ async function _initializeApp(state: any) {
 
     // Grab "Thunderstore mods per page" setting from store if possible
     const perPageFromStore: {value: number} | null = await persistentStore.get('thunderstore-mods-per-page');
-    if (perPageFromStore) {
+    if (perPageFromStore && perPageFromStore.value) {
         state.mods_per_page = perPageFromStore.value;
     }
 

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -35,7 +35,10 @@ export interface FlightCoreStore {
     installed_mods: NorthstarMod[],
 
     northstar_is_running: boolean,
-    origin_is_running: boolean
+    origin_is_running: boolean,
+
+    // user custom settings
+    mods_per_page: number
 }
 
 let notification_handle: NotificationHandle;
@@ -59,7 +62,9 @@ export const store = createStore<FlightCoreStore>({
             installed_mods: [],
 
             northstar_is_running: false,
-            origin_is_running: false
+            origin_is_running: false,
+
+            mods_per_page: 20
         }
     },
     mutations: {

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -324,6 +324,12 @@ async function _initializeApp(state: any) {
         state.enableReleasesSwitch = valueFromStore.value;
     }
 
+    // Grab "Thunderstore mods per page" setting from store if possible
+    const perPageFromStore: {value: number} | null = await persistentStore.get('thunderstore-mods-per-page');
+    if (perPageFromStore) {
+        state.mods_per_page = perPageFromStore.value;
+    }
+
     // Get FlightCore version number
     state.flightcore_version = await invoke("get_flightcore_version_number");
 

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -38,7 +38,7 @@ export interface FlightCoreStore {
     origin_is_running: boolean,
 
     // user custom settings
-    mods_per_page: number
+    mods_per_page: number,
 }
 
 let notification_handle: NotificationHandle;

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -64,7 +64,7 @@ export const store = createStore<FlightCoreStore>({
             northstar_is_running: false,
             origin_is_running: false,
 
-            mods_per_page: 20
+            mods_per_page: 20,
         }
     },
     mutations: {

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -18,7 +18,7 @@
                 <!-- Thunderstore mods per page configuration -->
                 <div class="fc_parameter__panel">
                     <h3>Number of Thunderstore mods per page</h3>
-                    <h6>This has an impact on display performances.</h6>
+                    <h6>This has an impact on display performances when browsing Thunderstore mods.</h6>
                     <el-input 
                         v-model="modsPerPage" 
                         type="number"

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -99,6 +99,13 @@ export default defineComponent({
     },
     mounted() {
         document.querySelector('input')!.disabled = true;
+    },
+    unmounted() {
+        const value = this.$store.state.mods_per_page;
+        if (value === '' || value < 5 || value > 100) {
+            console.warn('Incorrect value for modsPerPage, resetting it to 20.');
+            this.$store.state.mods_per_page = 20;
+        }
     }
 });
 </script>

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -18,7 +18,10 @@
                 <!-- Thunderstore mods per page configuration -->
                 <div class="fc_parameter__panel">
                     <h3>Number of Thunderstore mods per page</h3>
-                    <h6>This has an impact on display performances when browsing Thunderstore mods.</h6>
+                    <h6>
+                        This has an impact on display performances when browsing Thunderstore mods.<br>
+                        Set this value to 0 to disable pagination.
+                    </h6>
                     <el-input 
                         v-model="modsPerPage" 
                         type="number"

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -22,7 +22,11 @@
                     <el-input 
                         v-model="modsPerPage" 
                         type="number"
-                    ></el-input>
+                    >
+                        <template #append>
+                            <el-button @click="modsPerPage = 20">Reset to default</el-button>
+                        </template>
+                    </el-input>
                 </div>
 
                 <h3>About:</h3>

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -14,6 +14,14 @@
                         <el-button icon="Folder" @click="updateGamePath"/>
                     </template>
                 </el-input>
+
+                <!-- Thunderstore mods per page configuration -->
+                <div class="fc_parameter__panel">
+                    <h3>Number of Thunderstore mods per page</h3>
+                    <h6>This has an impact on display performances.</h6>
+                    <el-input v-model="$store.state.mods_per_page" type="number"></el-input>
+                </div>
+
                 <h3>About:</h3>
                 <div class="fc_northstar__version" @click="activateDeveloperMode">
                     FlightCore Version: {{ flightcoreVersion === '' ? 'Unknown version' : `${flightcoreVersion}` }}
@@ -109,5 +117,20 @@ h3:first-of-type {
 
 .el-switch {
     margin-left: 50px;
+}
+
+
+/* Parameter panel styles */
+.fc_parameter__panel {
+    margin: 30px 0;
+}
+
+.fc_parameter__panel h3 {
+    margin-bottom: 5px;
+}
+
+.fc_parameter__panel h6 {
+    margin-top: 0;
+    margin-bottom: 12px;
 }
 </style>

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -20,7 +20,7 @@
                     <h3>Number of Thunderstore mods per page</h3>
                     <h6>This has an impact on display performances.</h6>
                     <el-input 
-                        v-model="$store.state.mods_per_page" 
+                        v-model="modsPerPage" 
                         type="number"
                         min="5"
                         max="100"
@@ -77,6 +77,15 @@ export default defineComponent({
                     this.$store.commit('toggleReleaseCandidate');
                 }
             }
+        },
+        modsPerPage: {
+            get(): number {
+                return this.$store.state.mods_per_page;
+            },
+            set(value: number) {
+                this.$store.state.mods_per_page = value;
+                persistentStore.set('thunderstore-mods-per-page', { value });
+            }
         }
     },
     methods: {
@@ -101,10 +110,9 @@ export default defineComponent({
         document.querySelector('input')!.disabled = true;
     },
     unmounted() {
-        const value = this.$store.state.mods_per_page;
-        if (value === '' || value < 5 || value > 100) {
+        if (this.modsPerPage === '' || this.modsPerPage < 5 || this.modsPerPage > 100) {
             console.warn('Incorrect value for modsPerPage, resetting it to 20.');
-            this.$store.state.mods_per_page = 20;
+            this.modsPerPage = 20;
         }
     }
 });

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -22,8 +22,6 @@
                     <el-input 
                         v-model="modsPerPage" 
                         type="number"
-                        min="5"
-                        max="100"
                     ></el-input>
                 </div>
 
@@ -110,7 +108,7 @@ export default defineComponent({
         document.querySelector('input')!.disabled = true;
     },
     unmounted() {
-        if (('' + this.modsPerPage) === '' || this.modsPerPage < 5 || this.modsPerPage > 100) {
+        if (('' + this.modsPerPage) === '') {
             console.warn('Incorrect value for modsPerPage, resetting it to 20.');
             this.modsPerPage = 20;
         }

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -110,7 +110,7 @@ export default defineComponent({
         document.querySelector('input')!.disabled = true;
     },
     unmounted() {
-        if (this.modsPerPage === '' || this.modsPerPage < 5 || this.modsPerPage > 100) {
+        if (('' + this.modsPerPage) === '' || this.modsPerPage < 5 || this.modsPerPage > 100) {
             console.warn('Incorrect value for modsPerPage, resetting it to 20.');
             this.modsPerPage = 20;
         }

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -19,7 +19,12 @@
                 <div class="fc_parameter__panel">
                     <h3>Number of Thunderstore mods per page</h3>
                     <h6>This has an impact on display performances.</h6>
-                    <el-input v-model="$store.state.mods_per_page" type="number"></el-input>
+                    <el-input 
+                        v-model="$store.state.mods_per_page" 
+                        type="number"
+                        min="5"
+                        max="100"
+                    ></el-input>
                 </div>
 
                 <h3>About:</h3>

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -15,7 +15,7 @@
 
                     <!-- Pagination -->
                     <el-pagination
-                        v-if="modsPerPage != 0"
+                        v-if="shouldDisplayPagination"
                         :currentPage="currentPageIndex + 1"
                         layout="prev, pager, next"
                         :page-size="modsPerPage"
@@ -39,7 +39,7 @@
                 <div class="filter_container">
                     <el-pagination
                         class="fc_bottom__pagination"
-                        v-if="modsPerPage != 0"
+                        v-if="shouldDisplayPagination"
                         :currentPage="currentPageIndex + 1"
                         layout="prev, pager, next"
                         :page-size="modsPerPage"
@@ -93,6 +93,9 @@ export default defineComponent({
             const endIndexCandidate = startIndex + perPageValue;
             const endIndex =  endIndexCandidate > this.modsList.length ? this.modsList.length : endIndexCandidate;
             return this.modsList.slice(startIndex, endIndex);
+        },
+        shouldDisplayPagination(): boolean {
+            return this.modsPerPage != 0 && this.modsList.length > this.modsPerPage;
         }
     },
     data() {

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -20,8 +20,15 @@
                     Try another search!
                 </div>
 
+                <el-pagination
+                    layout="prev, pager, next"
+                    :page-size="modsPerPage"
+                    :total="modsList.length"
+                    @current-change="(e) => currentPageIndex = e - 1"
+                />
+
                 <!-- Mod cards -->
-                <thunderstore-mod-card v-for="mod of modsList" v-bind:key="mod.name" :mod="mod" />
+                <thunderstore-mod-card v-for="mod of currentPageMods" v-bind:key="mod.name" :mod="mod" />
             </div>
         </el-scrollbar>
     </div>
@@ -44,6 +51,12 @@ export default defineComponent({
         },
         modsList(): ThunderstoreMod[] {
             return this.input.length === 0 || this.userIsTyping ? this.mods : this.filteredMods;
+        },
+        currentPageMods(): ThunderstoreMod[] {
+            const startIndex = this.currentPageIndex * this.modsPerPage;
+            const endIndexCandidate = startIndex + this.modsPerPage;
+            const endIndex =  endIndexCandidate > this.modsList.length ? this.modsList.length : endIndexCandidate;
+            return this.modsList.slice(startIndex, endIndex);
         }
     },
     data() {
@@ -52,7 +65,10 @@ export default defineComponent({
             filteredMods: [] as ThunderstoreMod[],
             modsBeingInstalled: [] as string[],
             userIsTyping: false,
-            debouncedSearch: this.debounce((i: string) => this.filterMods(i))
+            debouncedSearch: this.debounce((i: string) => this.filterMods(i)),
+
+            modsPerPage: 20,
+            currentPageIndex: 0
         };
     },
     methods: {
@@ -75,6 +91,8 @@ export default defineComponent({
          * lower case, to match mods regardless of font case.
          */
         filterMods(value: string) {
+            this.currentPageIndex = 0;
+
             if (value === '') {
                 this.filteredMods = [];
                 return;

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -16,6 +16,7 @@
                     <!-- Pagination -->
                     <el-pagination
                         v-if="modsPerPage != 0"
+                        :currentPage="currentPageIndex + 1"
                         layout="prev, pager, next"
                         :page-size="modsPerPage"
                         :total="modsList.length"
@@ -32,6 +33,17 @@
                 <!-- Mod cards -->
                 <thunderstore-mod-card v-for="mod of currentPageMods" v-bind:key="mod.name" :mod="mod" />
             </div>
+
+            <!-- Bottom pagination -->
+            <el-pagination
+                class="fc_bottom__pagination"
+                v-if="modsPerPage != 0"
+                :currentPage="currentPageIndex + 1"
+                layout="prev, pager, next"
+                :page-size="modsPerPage"
+                :total="modsList.length"
+                @current-change="(e: number) => currentPageIndex = e - 1"
+            />
         </el-scrollbar>
     </div>
 </template>
@@ -130,6 +142,10 @@ export default defineComponent({
 
 .card-container {
     margin: 0 auto;
+}
+
+.fc_bottom__pagination {
+    margin: 10px 0 15px !important;
 }
 
 /* Card container dynamic size */

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script lang="ts">
-import {defineComponent, ref} from 'vue';
+import { defineComponent, ref } from 'vue';
 import { ThunderstoreMod } from "../utils/thunderstore/ThunderstoreMod";
 import ThunderstoreModCard from "../components/ThunderstoreModCard.vue";
 import {ElScrollbar, ScrollbarInstance} from "element-plus";

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -143,7 +143,9 @@ export default defineComponent({
 }
 
 .filter_container {
-    margin: 5px;
+    margin: 5px auto;
+    padding: 0 5px;
+    max-width: 1000px;
 }
 
 .el-input {

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -35,15 +35,19 @@
             </div>
 
             <!-- Bottom pagination -->
-            <el-pagination
-                class="fc_bottom__pagination"
-                v-if="modsPerPage != 0"
-                :currentPage="currentPageIndex + 1"
-                layout="prev, pager, next"
-                :page-size="modsPerPage"
-                :total="modsList.length"
-                @current-change="onBottomPaginationChange"
-            />
+            <div class="card-container">
+                <div class="filter_container">
+                    <el-pagination
+                        class="fc_bottom__pagination"
+                        v-if="modsPerPage != 0"
+                        :currentPage="currentPageIndex + 1"
+                        layout="prev, pager, next"
+                        :page-size="modsPerPage"
+                        :total="modsList.length"
+                        @current-change="onBottomPaginationChange"
+                    />
+                </div>
+            </div>
         </el-scrollbar>
     </div>
 </template>

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -78,28 +78,16 @@ export default defineComponent({
         return {
             // This is the model for the search input.
             input: '',
-            // This is the treated value of search input, updated every few milliseconds (debounced)
+            // This is the treated value of search input
             searchValue: '',
 
             modsBeingInstalled: [] as string[],
             userIsTyping: false,
-            debouncedSearch: this.debounce((i: string) => this.filterMods(i)),
 
             currentPageIndex: 0
         };
     },
     methods: {
-        /**
-         * This is a debounced version of the filterMods method, that calls
-         * filterMods when user has stopped typing in the search bar (i.e.
-         * waits 300ms).
-         * It allows not to trigger filtering method (which is costly) each
-         * time user inputs a character.
-         */
-        onFilterTextChange (searchString: string) {
-            this.debouncedSearch(searchString);
-        },
-
         /**
          * This method is called each time search input is modified, and
          * triggered filtered mods recomputing by updating the `searchValue`
@@ -108,26 +96,9 @@ export default defineComponent({
          * This converts research string and all researched fields to
          * lower case, to match mods regardless of font case.
          */
-        filterMods(value: string) {
+         onFilterTextChange(value: string) {
             this.currentPageIndex = 0;
             this.searchValue = value.toLowerCase();
-        },
-
-        /**
-         * This debounces a method, i.e. it prevents input method from being called
-         * multiple times in a short period of time.
-         * Stolen from https://www.freecodecamp.org/news/javascript-debounce-example/
-         */
-        debounce (func: Function, timeout = 200) {
-            let timer: any;
-            return (...args: any) => {
-                this.userIsTyping = true;
-                clearTimeout(timer);
-                timer = setTimeout(() => {
-                    this.userIsTyping = false;
-                    func.apply(this, args);
-                }, timeout);
-            };
         }
     }
 });

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -145,7 +145,8 @@ export default defineComponent({
 }
 
 .fc_bottom__pagination {
-    margin: 10px 0 15px !important;
+    padding-bottom: 20px !important;
+    padding-right: 10px;
 }
 
 /* Card container dynamic size */

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -129,10 +129,6 @@ export default defineComponent({
 </script>
 
 <style scoped>
-.el-pagination {
-    float: right;
-}
-
 .fc__changelog__container {
     padding: 20px 30px;
 }
@@ -140,16 +136,6 @@ export default defineComponent({
 .el-timeline-item__timestamp {
     color: white !important;
     user-select: none !important;
-}
-
-.filter_container {
-    margin: 5px auto;
-    padding: 0 5px;
-    max-width: 1000px;
-}
-
-.el-input {
-    max-width: 300px;
 }
 
 .search {
@@ -177,6 +163,11 @@ export default defineComponent({
     .card-container {
         width: 574px;
     }
+
+    .el-pagination {
+        float: none;
+        margin-top: 5px;
+    }
 }
 
 @media (max-width: 624px) {
@@ -185,9 +176,34 @@ export default defineComponent({
     }
 }
 
+.filter_container {
+    margin-bottom: 10px;
+}
+
+.el-input {
+    max-width: 200px;
+}
+
+@media (min-width: 812px) {
+    .filter_container {
+        margin: 5px auto;
+        padding: 0 5px;
+        max-width: 1000px;
+    }
+
+    .el-pagination {
+        float: right;
+        margin: 0;
+    }
+}
+
 @media (min-width: 1000px) {
     .card-container {
         width: 940px;
+    }
+
+    .el-input {
+        max-width: 300px;
     }
 }
 

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -56,7 +56,7 @@
 import { defineComponent, ref } from 'vue';
 import { ThunderstoreMod } from "../utils/thunderstore/ThunderstoreMod";
 import ThunderstoreModCard from "../components/ThunderstoreModCard.vue";
-import {ElScrollbar, ScrollbarInstance} from "element-plus";
+import { ElScrollbar, ScrollbarInstance } from "element-plus";
 
 export default defineComponent({
     name: "ThunderstoreModsView",

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -51,7 +51,7 @@ export default defineComponent({
             return this.$store.state.thunderstoreMods;
         },
         modsList(): ThunderstoreMod[] {
-            return this.input.length === 0 || this.userIsTyping ? this.mods : this.filteredMods;
+            return this.input.length !== 0 || this.userIsTyping ? this.filteredMods : this.mods;
         },
         currentPageMods(): ThunderstoreMod[] {
             const startIndex = this.currentPageIndex * this.modsPerPage;
@@ -93,12 +93,6 @@ export default defineComponent({
          */
         filterMods(value: string) {
             this.currentPageIndex = 0;
-
-            if (value === '') {
-                this.filteredMods = [];
-                return;
-            }
-
             const searchValue = value.toLowerCase();
 
             this.filteredMods = this.mods.filter((mod: ThunderstoreMod) => {

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -65,7 +65,7 @@ export default defineComponent({
             return this.input.length !== 0 || this.userIsTyping ? this.filteredMods : this.mods;
         },
         modsPerPage(): number {
-            return +this.$store.state.mods_per_page;
+            return parseInt(this.$store.state.mods_per_page);
         },
         currentPageMods(): ThunderstoreMod[] {
             const startIndex = this.currentPageIndex * this.modsPerPage;

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -18,7 +18,7 @@
                         layout="prev, pager, next"
                         :page-size="modsPerPage"
                         :total="modsList.length"
-                        @current-change="(e) => currentPageIndex = e - 1"
+                        @current-change="(e: number) => currentPageIndex = e - 1"
                     />
                 </div>
 

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -64,6 +64,9 @@ export default defineComponent({
         modsList(): ThunderstoreMod[] {
             return this.input.length !== 0 || this.userIsTyping ? this.filteredMods : this.mods;
         },
+        modsPerPage(): number {
+            return +this.$store.state.mods_per_page;
+        },
         currentPageMods(): ThunderstoreMod[] {
             const startIndex = this.currentPageIndex * this.modsPerPage;
             const endIndexCandidate = startIndex + this.modsPerPage;
@@ -82,7 +85,6 @@ export default defineComponent({
             userIsTyping: false,
             debouncedSearch: this.debounce((i: string) => this.filterMods(i)),
 
-            modsPerPage: 20,
             currentPageIndex: 0
         };
     },

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -3,7 +3,7 @@
         <div v-if="mods.length === 0" class="fc__changelog__container">
             <el-progress :show-text="false" :percentage="50" :indeterminate="true" />
         </div>
-        <el-scrollbar v-else class="container">
+        <el-scrollbar v-else class="container" ref="scrollbar">
             <div class="card-container">
                 <!-- Search filters -->
                 <div class="filter_container">
@@ -42,16 +42,17 @@
                 layout="prev, pager, next"
                 :page-size="modsPerPage"
                 :total="modsList.length"
-                @current-change="(e: number) => currentPageIndex = e - 1"
+                @current-change="onBottomPaginationChange"
             />
         </el-scrollbar>
     </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import {defineComponent, ref} from 'vue';
 import { ThunderstoreMod } from "../utils/thunderstore/ThunderstoreMod";
 import ThunderstoreModCard from "../components/ThunderstoreModCard.vue";
+import {ElScrollbar, ScrollbarInstance} from "element-plus";
 
 export default defineComponent({
     name: "ThunderstoreModsView",
@@ -115,6 +116,14 @@ export default defineComponent({
          onFilterTextChange(value: string) {
             this.currentPageIndex = 0;
             this.searchValue = value.toLowerCase();
+        },
+
+        /**
+         * This updates current pagination and scrolls view to the top.
+         */
+        onBottomPaginationChange(index: number) {
+            this.currentPageIndex = index - 1;
+            (this.$refs.scrollbar as ScrollbarInstance).scrollTo({ top: 0, behavior: 'smooth' });
         }
     }
 });

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -12,6 +12,14 @@
                     <div v-if="userIsTyping" class="modMessage search">
                         Searching mods...
                     </div>
+
+                    <!-- Pagination -->
+                    <el-pagination
+                        layout="prev, pager, next"
+                        :page-size="modsPerPage"
+                        :total="modsList.length"
+                        @current-change="(e) => currentPageIndex = e - 1"
+                    />
                 </div>
 
                 <!-- Message displayed if no mod matched searched words -->
@@ -19,13 +27,6 @@
                     No matching mod has been found.<br/>
                     Try another search!
                 </div>
-
-                <el-pagination
-                    layout="prev, pager, next"
-                    :page-size="modsPerPage"
-                    :total="modsList.length"
-                    @current-change="(e) => currentPageIndex = e - 1"
-                />
 
                 <!-- Mod cards -->
                 <thunderstore-mod-card v-for="mod of currentPageMods" v-bind:key="mod.name" :mod="mod" />
@@ -128,6 +129,10 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.el-pagination {
+    float: right;
+}
+
 .fc__changelog__container {
     padding: 20px 30px;
 }

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -15,6 +15,7 @@
 
                     <!-- Pagination -->
                     <el-pagination
+                        v-if="modsPerPage != 0"
                         layout="prev, pager, next"
                         :page-size="modsPerPage"
                         :total="modsList.length"
@@ -68,8 +69,11 @@ export default defineComponent({
             return parseInt(this.$store.state.mods_per_page);
         },
         currentPageMods(): ThunderstoreMod[] {
-            const startIndex = this.currentPageIndex * this.modsPerPage;
-            const endIndexCandidate = startIndex + this.modsPerPage;
+            // User might want to display all mods on one page.
+            const perPageValue = this.modsPerPage != 0 ? this.modsPerPage : this.modsList.length;
+
+            const startIndex = this.currentPageIndex * perPageValue;
+            const endIndexCandidate = startIndex + perPageValue;
             const endIndex =  endIndexCandidate > this.modsList.length ? this.modsList.length : endIndexCandidate;
             return this.modsList.slice(startIndex, endIndex);
         }

--- a/src-vue/src/views/ThunderstoreModsView.vue
+++ b/src-vue/src/views/ThunderstoreModsView.vue
@@ -50,6 +50,17 @@ export default defineComponent({
         mods(): ThunderstoreMod[] {
             return this.$store.state.thunderstoreMods;
         },
+        filteredMods(): ThunderstoreMod[] {
+            if (this.searchValue.length === 0) {
+                return this.mods;
+            }
+
+            return this.mods.filter((mod: ThunderstoreMod) => {
+                return mod.name.toLowerCase().includes(this.searchValue)
+                    || mod.owner.toLowerCase().includes(this.searchValue)
+                    || mod.versions[0].description.toLowerCase().includes(this.searchValue);
+            });
+        },
         modsList(): ThunderstoreMod[] {
             return this.input.length !== 0 || this.userIsTyping ? this.filteredMods : this.mods;
         },
@@ -62,8 +73,11 @@ export default defineComponent({
     },
     data() {
         return {
+            // This is the model for the search input.
             input: '',
-            filteredMods: [] as ThunderstoreMod[],
+            // This is the treated value of search input, updated every few milliseconds (debounced)
+            searchValue: '',
+
             modsBeingInstalled: [] as string[],
             userIsTyping: false,
             debouncedSearch: this.debounce((i: string) => this.filterMods(i)),
@@ -86,20 +100,15 @@ export default defineComponent({
 
         /**
          * This method is called each time search input is modified, and
-         * filters mods matching the input string.
+         * triggered filtered mods recomputing by updating the `searchValue`
+         * variable.
          *
          * This converts research string and all researched fields to
          * lower case, to match mods regardless of font case.
          */
         filterMods(value: string) {
             this.currentPageIndex = 0;
-            const searchValue = value.toLowerCase();
-
-            this.filteredMods = this.mods.filter((mod: ThunderstoreMod) => {
-                return mod.name.toLowerCase().includes(searchValue)
-                    || mod.owner.toLowerCase().includes(searchValue)
-                    || mod.versions[0].description.toLowerCase().includes(searchValue);
-            });
+            this.searchValue = value.toLowerCase();
         },
 
         /**


### PR DESCRIPTION
This introduces pagination for Thunderstore mods, not displaying all of them at once to improve performances.
Pagination is sensible to mods filtering.

![pagination](https://user-images.githubusercontent.com/11993538/209452417-6ae08fc1-9141-40ee-b295-e18287766d96.gif)

![mod pages setting](https://user-images.githubusercontent.com/11993538/210415064-644e91f2-b12a-4c8f-8366-f8050e8960b3.png)

##### TODOs

- [x] Add a setting for users to set number of mods per page
- [x] Check if I can get rid of debouncing (I feel like setting `filteredMods` as a computed property improved filtering speed a lot)