### PR TITLE
refactor: Deserialize into struct directly

### DIFF
--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -91,28 +91,9 @@ pub async fn get_northstar_release_notes() -> Result<Vec<ReleaseInfo>, String> {
     let url = "https://api.github.com/repos/R2Northstar/Northstar/releases";
     let res = fetch_github_releases_api(url).await?;
 
-    let json_response: Vec<serde_json::Value> =
+    let release_info_vector: Vec<ReleaseInfo> =
         serde_json::from_str(&res).expect("JSON was not well-formatted");
     println!("Done checking GitHub API");
 
-    return Ok(json_response
-        .iter()
-        .map(|release| ReleaseInfo {
-            name: release
-                .get("name")
-                .and_then(|value| value.as_str())
-                .unwrap()
-                .to_string(),
-            published_at: release
-                .get("published_at")
-                .and_then(|value| value.as_str())
-                .unwrap()
-                .to_string(),
-            body: release
-                .get("body")
-                .and_then(|value| value.as_str())
-                .unwrap()
-                .to_string(),
-        })
-        .collect());
+    return Ok(release_info_vector);
 }


### PR DESCRIPTION
Instead of deserializing into a generic serde struct and then extracting specific value from it, deserialize directly into the struct we want.

Basically less lines of code thanks to serde :sparkles: magic :sparkles: 