### PR TITLE
refactor: Remove unnecessary caller function pattern

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -91,7 +91,7 @@ fn main() {
             launch_northstar_caller,
             check_is_flightcore_outdated_caller,
             get_log_list_caller,
-            verify_game_files_caller,
+            verify_game_files,
             set_mod_enabled_status,
             disable_all_but_core,
             is_debug_mode,
@@ -276,11 +276,6 @@ async fn launch_northstar_caller(
 /// Get list of Northstar logs
 async fn get_log_list_caller(game_install: GameInstall) -> Result<Vec<std::path::PathBuf>, String> {
     get_log_list(game_install)
-}
-
-#[tauri::command]
-async fn verify_game_files_caller(game_install: GameInstall) -> Result<String, String> {
-    verify_game_files(game_install)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
             is_debug_mode,
             get_northstar_release_notes,
             linux_checks,
-            get_installed_mods_caller,
+            get_installed_mods_and_properties,
             install_mod_caller,
             clean_up_download_folder_caller,
         ])
@@ -298,11 +298,6 @@ async fn set_mod_enabled_status_caller(
     is_enabled: bool,
 ) -> Result<(), String> {
     set_mod_enabled_status(game_install, mod_name, is_enabled)
-}
-
-#[tauri::command]
-async fn get_installed_mods_caller(game_install: GameInstall) -> Result<Vec<NorthstarMod>, String> {
-    get_installed_mods_and_properties(game_install)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -94,7 +94,7 @@ fn main() {
             verify_game_files_caller,
             get_enabled_mods_caller,
             set_mod_enabled_status_caller,
-            disable_all_but_core_caller,
+            disable_all_but_core,
             is_debug_mode,
             get_northstar_release_notes,
             linux_checks,
@@ -298,11 +298,6 @@ async fn set_mod_enabled_status_caller(
     is_enabled: bool,
 ) -> Result<(), String> {
     set_mod_enabled_status(game_install, mod_name, is_enabled)
-}
-
-#[tauri::command]
-async fn disable_all_but_core_caller(game_install: GameInstall) -> Result<(), String> {
-    disable_all_but_core(game_install)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
             check_is_flightcore_outdated_caller,
             get_log_list_caller,
             verify_game_files_caller,
-            set_mod_enabled_status_caller,
+            set_mod_enabled_status,
             disable_all_but_core,
             is_debug_mode,
             get_northstar_release_notes,
@@ -281,15 +281,6 @@ async fn get_log_list_caller(game_install: GameInstall) -> Result<Vec<std::path:
 #[tauri::command]
 async fn verify_game_files_caller(game_install: GameInstall) -> Result<String, String> {
     verify_game_files(game_install)
-}
-
-#[tauri::command]
-async fn set_mod_enabled_status_caller(
-    game_install: GameInstall,
-    mod_name: String,
-    is_enabled: bool,
-) -> Result<(), String> {
-    set_mod_enabled_status(game_install, mod_name, is_enabled)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -90,7 +90,7 @@ fn main() {
             update_northstar_caller,
             launch_northstar_caller,
             check_is_flightcore_outdated_caller,
-            get_log_list_caller,
+            get_log_list,
             verify_game_files,
             set_mod_enabled_status,
             disable_all_but_core,
@@ -270,12 +270,6 @@ async fn launch_northstar_caller(
     bypass_checks: Option<bool>,
 ) -> Result<String, String> {
     launch_northstar(game_install, bypass_checks)
-}
-
-#[tauri::command]
-/// Get list of Northstar logs
-async fn get_log_list_caller(game_install: GameInstall) -> Result<Vec<std::path::PathBuf>, String> {
-    get_log_list(game_install)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -92,7 +92,6 @@ fn main() {
             check_is_flightcore_outdated_caller,
             get_log_list_caller,
             verify_game_files_caller,
-            get_enabled_mods_caller,
             set_mod_enabled_status_caller,
             disable_all_but_core,
             is_debug_mode,
@@ -282,13 +281,6 @@ async fn get_log_list_caller(game_install: GameInstall) -> Result<Vec<std::path:
 #[tauri::command]
 async fn verify_game_files_caller(game_install: GameInstall) -> Result<String, String> {
     verify_game_files(game_install)
-}
-
-#[tauri::command]
-async fn get_enabled_mods_caller(
-    game_install: GameInstall,
-) -> Result<serde_json::value::Value, String> {
-    get_enabled_mods(game_install)
 }
 
 #[tauri::command]

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -185,6 +185,7 @@ fn parse_installed_mods(game_install: GameInstall) -> Result<Vec<NorthstarMod>, 
 /// Gets list of installed mods and their properties
 /// - name
 /// - is enabled?
+#[tauri::command]
 pub fn get_installed_mods_and_properties(
     game_install: GameInstall,
 ) -> Result<Vec<NorthstarMod>, String> {

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -43,6 +43,7 @@ pub fn rebuild_enabled_mods_json(game_install: GameInstall) -> Result<(), String
 }
 
 /// Set the status of a passed mod to enabled/disabled
+#[tauri::command]
 pub fn set_mod_enabled_status(
     game_install: GameInstall,
     mod_name: String,

--- a/src-tauri/src/repair_and_verify/mod.rs
+++ b/src-tauri/src/repair_and_verify/mod.rs
@@ -64,6 +64,8 @@ pub fn clean_up_download_folder(
     Ok(())
 }
 
+/// Get list of Northstar logs
+#[tauri::command]
 pub fn get_log_list(game_install: GameInstall) -> Result<Vec<std::path::PathBuf>, String> {
     let ns_log_folder = format!("{}/R2Northstar/logs", game_install.game_path);
 

--- a/src-tauri/src/repair_and_verify/mod.rs
+++ b/src-tauri/src/repair_and_verify/mod.rs
@@ -4,6 +4,7 @@ use anyhow::anyhow;
 use app::{get_enabled_mods, GameInstall};
 
 /// Verifies Titanfall2 game files
+#[tauri::command]
 pub fn verify_game_files(game_install: GameInstall) -> Result<String, String> {
     dbg!(game_install);
     Err("TODO, not yet implemented".to_string())

--- a/src-tauri/src/repair_and_verify/mod.rs
+++ b/src-tauri/src/repair_and_verify/mod.rs
@@ -11,6 +11,7 @@ pub fn verify_game_files(game_install: GameInstall) -> Result<String, String> {
 
 /// Disables all mods except core ones
 /// Enables core mods if disabled
+#[tauri::command]
 pub fn disable_all_but_core(game_install: GameInstall) -> Result<(), String> {
 
     // Rebuild `enabledmods.json` first to ensure all mods are added

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -246,7 +246,7 @@ export const store = createStore<FlightCoreStore>({
             }
 
             // Call back-end for installed mods
-            await invoke("get_installed_mods_caller", { gameInstall: game_install })
+            await invoke("get_installed_mods_and_properties", { gameInstall: game_install })
                 .then((message) => {
                     state.installed_mods = (message as NorthstarMod[]);
                 })

--- a/src-vue/src/views/DeveloperView.vue
+++ b/src-vue/src/views/DeveloperView.vue
@@ -133,7 +133,7 @@ export default defineComponent({
                 game_path: this.$store.state.game_path,
                 install_type: this.$store.state.install_type
             } as GameInstall;
-            await invoke("get_installed_mods_caller", { gameInstall: game_install }).then((message) => {
+            await invoke("get_installed_mods_and_properties", { gameInstall: game_install }).then((message) => {
                 // Simply console logging for now
                 // In the future we should display the installed mods somewhere
                 console.log(message);

--- a/src-vue/src/views/DeveloperView.vue
+++ b/src-vue/src/views/DeveloperView.vue
@@ -111,7 +111,7 @@ export default defineComponent({
                 game_path: this.$store.state.game_path,
                 install_type: this.$store.state.install_type
             } as GameInstall;
-            await invoke("disable_all_but_core_caller", { gameInstall: game_install }).then((message) => {
+            await invoke("disable_all_but_core", { gameInstall: game_install }).then((message) => {
                 ElNotification({
                     title: 'Success',
                     message: "Disabled all mods but core",

--- a/src-vue/src/views/ModsView.vue
+++ b/src-vue/src/views/ModsView.vue
@@ -48,7 +48,7 @@ export default defineComponent({
 
             // enable/disable specific mod
             try {
-                await invoke("set_mod_enabled_status_caller", {
+                await invoke("set_mod_enabled_status", {
                     gameInstall: game_install,
                     modName: mod.name,
                     // Need to set it to the opposite of current state,


### PR DESCRIPTION
Removes the unnecessary `function_caller` pattern by just adding the `#[tauri::command]` macro to the corresponding function directly.

I couldn't remove the pattern for all functions cause some seem to throw weird compiler macro errors when I do. Needs further investigating but the adjusted functions in this PR all work fine ^^