### PR TITLE
refactor: Store global const in separate file

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -1,0 +1,3 @@
+// This file stores various global constants values
+
+pub const APP_USER_AGENT: &str = "R2NorthstarTools/FlightCore";

--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -1,3 +1,4 @@
+use crate::constants::APP_USER_AGENT;
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;
 
@@ -18,11 +19,10 @@ pub struct FlightCoreVersion {
 async fn fetch_github_releases_api(url: &str) -> Result<String, String> {
     println!("Fetching releases notes from GitHub API");
 
-    let user_agent = "R2NorthstarTools/FlightCore";
     let client = reqwest::Client::new();
     let res = client
         .get(url)
-        .header(reqwest::header::USER_AGENT, user_agent)
+        .header(reqwest::header::USER_AGENT, APP_USER_AGENT)
         .send()
         .await
         .unwrap()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Context, Result};
 
 mod northstar;
 
+pub mod constants;
 mod platform_specific;
 #[cfg(target_os = "windows")]
 use platform_specific::windows;


### PR DESCRIPTION
Moved user agent there for now.

Storing all global consts in a single file makes adjusting them easier as one also have to look at a single place. This is especially useful for anyone wanting to make their own spin/fork of the application (NorthstarCN _\*hint\*_ _\*hint\*_ ;P)