### PR TITLE
refactor: Bump libthermite

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1818,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "libthermite"
-version = "0.4.0-rc.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20679c4ed3e63c7f3c60a5a1accabd89db7d8759cf232963ad754fdf649c3229"
+checksum = "31ec1288a3f54f21ee6bd7eec92c5d098d9acc82d3bfdcf3c5ae29498ddfdc0e"
 dependencies = [
  "futures-util",
  "indicatif",
@@ -3237,18 +3237,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3257,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa 1.0.4",
  "ryu",
@@ -3939,18 +3939,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1818,17 +1818,14 @@ dependencies = [
 
 [[package]]
 name = "libthermite"
-version = "0.3.4"
+version = "0.4.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ced5f2756672c1379a5ee41771af8e1ead525a9f6b1e2a2139105a6754f6bb5"
+checksum = "20679c4ed3e63c7f3c60a5a1accabd89db7d8759cf232963ad754fdf649c3229"
 dependencies = [
- "directories",
  "futures-util",
  "indicatif",
  "log",
- "regex",
  "reqwest",
- "ron",
  "serde",
  "serde_json",
  "thiserror",
@@ -2992,17 +2989,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.37.0",
-]
-
-[[package]]
-name = "ron"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
-dependencies = [
- "base64",
- "bitflags",
- "serde",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ steamlocate = "1.0.2"
 # Error messages
 anyhow = "1.0"
 # libthermite for Northstar/mod install handling
-libthermite = "0.4.0-rc.1"
+libthermite = "0.4.0"
 # zip stuff
 zip = "0.6.2"
 # Regex

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ steamlocate = "1.0.2"
 # Error messages
 anyhow = "1.0"
 # libthermite for Northstar/mod install handling
-libthermite = "0.3.4"
+libthermite = "0.4.0-rc.1"
 # zip stuff
 zip = "0.6.2"
 # Regex

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -184,7 +184,7 @@ async fn do_install(nmod: &thermite::model::ModVersion, game_path: &std::path::P
     let download_path = format!("{}/{}", download_directory.clone(), filename);
     println!("{}", download_path);
 
-    let nfile = thermite::core::actions::download_file(&nmod.url, download_path)
+    let nfile = thermite::core::manage::download_file(&nmod.url, download_path)
         .await
         .unwrap();
 

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -331,8 +331,11 @@ pub async fn fc_download_mod_and_install(
         Err(e) => return Err(e.to_string()),
     };
 
+    // Get Thunderstore mod author
+    let author = thunderstore_mod_string.split("-").next().unwrap();
+
     // Extract the mod to the mods directory
-    match thermite::core::manage::install_mod(&f, std::path::Path::new(&mods_directory))
+    match thermite::core::manage::install_mod(author, &f, std::path::Path::new(&mods_directory))
     {
         Ok(()) => (),
         Err(err) => return Err(err.to_string()),

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -237,32 +237,6 @@ async fn get_ns_mod_download_url(thunderstore_mod_string: String) -> Result<Stri
     Err("Could not find mod on Thunderstore".to_string())
 }
 
-/// Adds given Thunderstore mod string to the given `mod.json`
-/// This way we can later check whether a mod is outdated based on the TS mod string
-fn add_thunderstore_mod_string(
-    path_to_mod_json: String,
-    thunderstore_mod_string: String,
-) -> Result<(), anyhow::Error> {
-    // Read file into string and parse it
-    let data = std::fs::read_to_string(path_to_mod_json.clone())?;
-    let parsed_json: serde_json::Value = json5::from_str(&data)?;
-
-    // Insert the Thunderstore mod string
-    let mut parsed_json = parsed_json.as_object().unwrap().clone();
-    parsed_json.insert(
-        "ThunderstoreModString".to_string(),
-        serde_json::Value::String(thunderstore_mod_string),
-    );
-
-    // And write back to disk
-    std::fs::write(
-        path_to_mod_json,
-        serde_json::to_string_pretty(&parsed_json)?,
-    )?;
-
-    Ok(())
-}
-
 /// Returns a vector of modstrings containing the dependencies of a given mod
 async fn get_mod_dependencies(
     thunderstore_mod_string: String,
@@ -352,35 +326,18 @@ pub async fn fc_download_mod_and_install(
     );
 
     // Download the mod
-    let f = match thermite::core::actions::download_file(&download_url, path.clone()).await {
+    let f = match thermite::core::manage::download_file(&download_url, path.clone()).await {
         Ok(f) => f,
         Err(e) => return Err(e.to_string()),
     };
 
     // Extract the mod to the mods directory
-    let pkg = match thermite::core::actions::install_mod(&f, std::path::Path::new(&mods_directory))
+    match thermite::core::manage::install_mod(&f, std::path::Path::new(&mods_directory))
     {
-        Ok(pkg) => pkg,
+        Ok(()) => (),
         Err(err) => return Err(err.to_string()),
     };
-    dbg!(pkg.clone());
 
-    // Add Thunderstore mod string to `mod.json` of installed NorthstarMods
-    for nsmod in pkg.mods {
-        let path_to_current_mod_json = format!(
-            "{}/{}/mod.json",
-            mods_directory,
-            nsmod.path.to_string_lossy()
-        );
-        match add_thunderstore_mod_string(path_to_current_mod_json, thunderstore_mod_string.clone())
-        {
-            Ok(()) => (),
-            Err(err) => {
-                println!("Failed setting modstring for {}", nsmod.name);
-                println!("{}", err);
-            }
-        }
-    }
 
     // Delete downloaded zip file
     std::fs::remove_file(path).unwrap();

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -3,6 +3,8 @@ use async_recursion::async_recursion;
 
 use anyhow::{anyhow, Result};
 use app::NorthstarMod;
+use serde::{Deserialize, Serialize};
+use std::io::Read;
 use std::path::PathBuf;
 
 use app::get_enabled_mods;
@@ -41,6 +43,12 @@ impl std::str::FromStr for ParsedThunderstoreModString {
             version,
         })
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ThunderstoreManifest {
+    name: String,
+    version_number: String,
 }
 
 /// Gets all currently installed and enabled/disabled mods to rebuild `enabledmods.json`
@@ -133,6 +141,7 @@ fn parse_mod_json_for_mod_name(mod_json_path: String) -> Result<String, anyhow::
 }
 
 /// Parses `mod.json` for Thunderstore mod string
+/// This is a legacy function as nowadays `manifest.json` should be in Northtar mods folder and read from there
 // TODO: Maybe pass PathBuf or serde json object
 fn parse_mod_json_for_thunderstore_mod_string(
     mod_json_path: String,
@@ -151,6 +160,33 @@ fn parse_mod_json_for_thunderstore_mod_string(
     };
 
     Ok(thunderstore_mod_string.to_string())
+}
+
+/// Parses `manifest.json` for Thunderstore mod string
+fn parse_for_thunderstore_mod_string(nsmod_path: String) -> Result<String, anyhow::Error> {
+    let mod_json_path = format!("{}/mod.json", nsmod_path);
+    let manifest_json_path = format!("{}/manifest.json", nsmod_path);
+    let ts_author_txt_path = format!("{}/thunderstore_author.txt", nsmod_path);
+
+    // Attempt legacy method for getting Thunderstore string first
+    match parse_mod_json_for_thunderstore_mod_string(mod_json_path) {
+        Ok(thunderstore_mod_string) => return Ok(thunderstore_mod_string),
+        Err(_err) => (),
+    }
+
+    // Check if `manifest.json` exists and parse
+    let data = std::fs::read_to_string(manifest_json_path)?;
+    let thunderstore_manifest: ThunderstoreManifest = json5::from_str(&data)?;
+
+    // Check if `thunderstore_author.txt` exists and parse
+    let mut file = std::fs::File::open(ts_author_txt_path)?;
+    let mut thunderstore_author = String::new();
+    file.read_to_string(&mut thunderstore_author)?;
+
+    // Build mod string
+    let thunderstore_mod_string = format!("{}-{}-{}", thunderstore_author, thunderstore_manifest.name, thunderstore_manifest.version_number);
+
+    Ok(thunderstore_mod_string)
 }
 
 /// Parse `mods` folder for installed mods.
@@ -174,8 +210,9 @@ fn parse_installed_mods(game_install: GameInstall) -> Result<Vec<NorthstarMod>, 
 
     // Iterate over folders and check if they are Northstar mods
     for directory in directories {
+        let directory_str = directory.to_str().unwrap().to_string();
         // Check if mod.json exists
-        let mod_json_path = format!("{}/mod.json", directory.to_str().unwrap());
+        let mod_json_path = format!("{}/mod.json", directory_str);
         if !std::path::Path::new(&mod_json_path).exists() {
             continue;
         }
@@ -188,8 +225,9 @@ fn parse_installed_mods(game_install: GameInstall) -> Result<Vec<NorthstarMod>, 
                 continue;
             }
         };
+        // Get Thunderstore mod string if it exists
         let thunderstore_mod_string =
-            match parse_mod_json_for_thunderstore_mod_string(mod_json_path.clone()) {
+            match parse_for_thunderstore_mod_string(directory_str) {
                 Ok(thunderstore_mod_string) => Some(thunderstore_mod_string),
                 Err(_err) => None,
             };


### PR DESCRIPTION
This updates to version `0.4.0` of [`libthermite`](https://crates.io/crates/libthermite).


In the process, we now also no longer write the Thunderstore mod string to the Northstar mod's `mod.json` but rather copy the `manifest.json` from the Thunderstore mod into the Northstar mod and add a file called `thunderstore_author.txt` that contains the author name of the Thunderstore mod to uniquely map a Northstar mod to a Thunderstore mod.
This is done to increase compatibility with Viper and VTOL. See also the discussion here: https://github.com/0neGal/viper/issues/165

Reading `mod.json` for Thunderstore string is still supported for the time being. In the future it will be changed to a "converter" and then later will be fully deprecated.