### PR TITLE
fix: Remove unused serde import in `main.rs`

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,7 +30,6 @@ use mod_management::{
 mod northstar;
 use northstar::get_northstar_version_number;
 
-use serde::{Deserialize, Serialize};
 use tauri::Manager;
 use tauri_plugin_store::PluginBuilder;
 use tokio::time::sleep;


### PR DESCRIPTION
Seems like I forgot to remove it when I did some code refactoring. Removes a compiler warning about unused imports.