### PR TITLE
feat: Add Rust code format check to CI

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -51,9 +51,8 @@ jobs:
     - name: format-check
       uses: actions-rs/cargo@v1
       with:
-        path: src-tauri
         command: fmt
-        args: --all -- --check
+        args: --manifest-path src-tauri/Cargo.toml --all -- --check
     - name: install app dependencies and build it
       env:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -48,6 +48,12 @@ jobs:
       with:
         workspaces: |
           src-tauri
+    - name: format-check
+      uses: actions-rs/cargo@v1
+      with:
+        path: src-tauri
+        command: fmt
+        args: --all -- --check
     - name: install app dependencies and build it
       env:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -14,6 +14,22 @@ jobs:
         run: |
           python3 scripts/check_version_numbers.py
 
+  # Ensure correct Rust code formatting
+  fmt:
+    name: format-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path src-tauri/Cargo.toml --all -- --check
 
   test-tauri:
     needs: ensure-same-version
@@ -48,11 +64,6 @@ jobs:
       with:
         workspaces: |
           src-tauri
-    - name: format-check
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --manifest-path src-tauri/Cargo.toml --all -- --check
     - name: install app dependencies and build it
       env:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -15,7 +15,7 @@ jobs:
           python3 scripts/check_version_numbers.py
 
   # Ensure correct Rust code formatting
-  fmt:
+  formatting:
     name: format-check
     runs-on: ubuntu-latest
     steps:

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }


### PR DESCRIPTION
Performs source code formatting check in CI and fails if the formatting is wrong.

TODO:

- [x] change it so that it runs in parallel next to other tasks.

Closes #144