### PR TITLE
docs: Redirector to up-to-date releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 	<img src="docs/assets/Square310x310Logo.png" width="200px">
 	<br>
 	<br>
-	<a href="https://github.com/R2NorthstarTools/FlightCore/releases/download/v1.6.0/FlightCore_1.6.0_x64_en-US.msi"><img src="docs/assets/downloadbutton.png" width="300px"></a>
+	<a href="https://r2northstartools.github.io/FlightCore/index.html?win-setup"><img src="docs/assets/downloadbutton.png" width="300px"></a>
 	<br>
 </p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,64 @@
+<script>
+// with this we can very easily fetch the latest version of FlightCore
+// and redirect to it, without having to update any version numbers on
+// every release, simply change the search query to either "win-setup"
+// or "appimage", without a query you will be redirect to the release
+// page instead of the download
+//
+// so generally a request would look like this:
+// 
+//    r2northstartools.github.io/FlightCore/index.html?win-setup
+//
+// or
+//
+//    r2northstartools.github.io/FlightCore/index.html?appimage
+//
+// and to redirect to the release page:
+//
+//    r2northstartools.github.io/FlightCore/index.html
+
+(async () => {
+	// configuration of repo URL
+	let repo = "FlightCore";
+	let author = "R2NorthstarTools";
+	let api = "https://api.github.com/repos";
+
+	// actual API request
+	let release = await (await fetch(`${api}/${author}/${repo}/releases/latest`)).json();
+	let assets = release.assets;
+
+	// this takes in a regEx and if something matches in the release's
+	// files, it'll return the download link to it
+	let get = (asset) => {
+		for (let i in assets) {
+			if (assets[i].name.match(asset)) {
+				return assets[i].browser_download_url;
+			}
+		}
+	}
+
+	let url;
+
+	// this refers to the actual search query, i.e "<page>?appimage"
+	let search = location.search.replace(/^\?/, "");
+	switch(search) {
+		case "win-zip": // FlightCore_<version>_x64_en-US.zip
+			url = get(/FlightCore_.*\.zip$/);
+			break;
+		case "win-setup": // FlightCore_<version>_x64_en-US.msi
+			url = get(/FlightCore_.*\.msi$/);
+			break;
+
+		case "appimage": // flight-core_<version>_amd64.AppImage
+			url = get(/flight-core_.*\.AppImage$/);
+			break;
+
+		default: // default to release page
+			url = release.html_url;
+			break;
+	}
+
+	// redirect to page
+	location.replace(url);
+})()
+</script>


### PR DESCRIPTION
This PR introduces the `docs/index.html` file which when loaded will take in varies queries then redirect you to the latest release page or files, without having to update the version numbers every release, as it fetches the latest automatically.

When deployed you should be able to go to the following links, and the various files should just download, the last one will however redirect you to the latest release page instead, as a fallback. I also took the liberty of changing the README's download link to match.

[r2northstartools.github.io/FlightCore/index.html?win-setup](https://r2northstartools.github.io/FlightCore/index.html?win-setup)<br> ---> FlightCore_<version>_x64_en-US.msi

[r2northstartools.github.io/FlightCore/index.html?win-zip](https://r2northstartools.github.io/FlightCore/index.html?win-zip)<br> ---> FlightCore_<version>_x64_en-US.zip

[r2northstartools.github.io/FlightCore/index.html?appimage](https://r2northstartools.github.io/FlightCore/index.html?appimage)<br> ---> flight-core_<version>_amd64.appimage

[r2northstartools.github.io/FlightCore/index.html](https://r2northstartools.github.io/FlightCore/index.html)<br> ---> latest release page

<br><br>

As for deploying, simply go into the Pages settings page, enable and set it to use the `main` branch and the `/docs` folder

![image](https://user-images.githubusercontent.com/33325154/215823774-1427286e-f58f-4ec9-9abc-1b5d88ae6a8a.png)

<br><br>

And then it should be working! :)