### PR TITLE
refactor: Deal with `fs::read_dir` failure instead of checking if exists

### DIFF
--- a/src-tauri/src/repair_and_verify/mod.rs
+++ b/src-tauri/src/repair_and_verify/mod.rs
@@ -71,6 +71,7 @@ pub fn clean_up_download_folder(
 pub fn get_log_list(game_install: GameInstall) -> Result<Vec<std::path::PathBuf>, String> {
     let ns_log_folder = format!("{}/R2Northstar/logs", game_install.game_path);
 
+    // List files in logs folder
     let paths = match std::fs::read_dir(ns_log_folder) {
         Ok(paths) => paths,
         Err(_err) => return Err("No logs folder found".to_string()),

--- a/src-tauri/src/repair_and_verify/mod.rs
+++ b/src-tauri/src/repair_and_verify/mod.rs
@@ -71,13 +71,10 @@ pub fn clean_up_download_folder(
 pub fn get_log_list(game_install: GameInstall) -> Result<Vec<std::path::PathBuf>, String> {
     let ns_log_folder = format!("{}/R2Northstar/logs", game_install.game_path);
 
-    // Check if logs folder exists
-    if !std::path::Path::new(&ns_log_folder).exists() {
-        return Err("No logs folder found".to_string());
-    }
-
-    // List files in logs folder
-    let paths = std::fs::read_dir(ns_log_folder).unwrap();
+    let paths = match std::fs::read_dir(ns_log_folder) {
+        Ok(paths) => paths,
+        Err(_err) => return Err("No logs folder found".to_string()),
+    };
 
     // Stores paths of log files
     let mut log_files: Vec<std::path::PathBuf> = Vec::new();


### PR DESCRIPTION
As discussed in #152