### PR TITLE
refactor: Parse using serde deserialisation

### DIFF
--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -57,18 +57,6 @@ pub struct ModJson {
     name: String,
     #[serde(rename = "ThunderstoreModString")]
     thunderstore_mod_string: Option<String>,
-    // Currently unused fields commented out
-    // Comment in when needed
-    // #[serde(rename = "Description")]
-    // description: Option<String>,
-    // #[serde(rename = "Version")]
-    // version: Option<String>,
-    // #[serde(rename = "LoadPriority")]
-    // load_priority: Option<i32>,
-    // #[serde(rename = "Authors")]
-    // authors: Option<Vec<String>>,
-    // #[serde(rename = "RequiredOnClient")]
-    // require_on_client: Option<bool>,
 }
 
 /// Gets all currently installed and enabled/disabled mods to rebuild `enabledmods.json`


### PR DESCRIPTION
This gets rid of a bunch of code by making use of [`serde`](https://crates.io/crates/serde) functionality. This should have honestly been written like this in the first place but when I first used `serde` I wasn't aware of that functionality even though it's its defining feature ^^"