### PR TITLE
feat: Change default resolution to SteamDeck size

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -64,9 +64,9 @@
         "resizable": true,
         "decorations": false,
         "title": "FlightCore",
-        "height": 600,
+        "height": 800,
         "minHeight": 300,
-        "width": 1000,
+        "width": 1280,
         "minWidth": 600
       }
     ]


### PR DESCRIPTION
This should give us fullscreen FlightCore out of the box when opening it in game UI. To my knowledge gamescope has no easy way of resizing window after opening.

This sidesteps it by just launching window in screen size.


As a nice side effect, this means by default more columns of mods are shown in the Thunderstore mod browser, previously it was just too small to fit 4 instead of 3 columns, making it look a bit awkward.

Before:
![image](https://user-images.githubusercontent.com/40122905/216841990-8805c63e-7333-4d55-9eb9-50e37240b557.png)

After:
![image](https://user-images.githubusercontent.com/40122905/216841904-c8731b9b-1c2e-4da2-bcce-b2417daef742.png)
