### PR TITLE
fix: Slightly increase window size to better fit list of mods in Thunderstore mod browser

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -66,7 +66,7 @@
         "title": "FlightCore",
         "height": 600,
         "minHeight": 300,
-        "width": 1000,
+        "width": 1010,
         "minWidth": 600
       }
     ]


### PR DESCRIPTION
Seems like +10px on the horizontal was enough ^^

Before:
![image](https://user-images.githubusercontent.com/40122905/217050436-44a47a34-36e8-4171-8b2c-c57e13d3f4d4.png)

vs with this PR:
![image](https://user-images.githubusercontent.com/40122905/217050336-3704f22a-c762-46ae-9772-4a1014fe320e.png)

Supersedes #165 somewhat