### PR TITLE
feat: Add version number to user-agent

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "chrono",
+ "const_format",
  "game-scanner",
  "json5",
  "libthermite",
@@ -458,6 +459,26 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4236,6 +4257,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,8 @@ game-scanner = "1.1.4"
 chrono = "0.4.23"
 # TypeScript bindings
 ts-rs = "6.1"
+# const formatting
+const_format = "0.2.30"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -2,6 +2,7 @@
 
 use const_format::concatcp;
 
+// FlightCore user agent for web requests
 pub const APP_USER_AGENT: &str = concatcp!("FlightCore/", env!("CARGO_PKG_VERSION"));
 
 // URL of the Northstar masterserver

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -1,6 +1,8 @@
 // This file stores various global constants values
 
-pub const APP_USER_AGENT: &str = "R2NorthstarTools/FlightCore";
+use const_format::concatcp;
+
+pub const APP_USER_AGENT: &str = concatcp!("FlightCore/", env!("CARGO_PKG_VERSION"));
 
 // URL of the Northstar masterserver
 pub const MASTER_SERVER_URL: &str = "https://northstar.tf";


### PR DESCRIPTION
Uses a crate that allows for formatting at compile time.

User agent is `FlightCore/MAJOR.MINOR.PATCH`, e.g. currently `FlightCore/1.7.0`.

Among other things, this allows for seeing percentage of different versions deployed on masterserver when FlightCore performs query to `/client/servers`.

Closes #170 