### PR TITLE
refactor: Properly set cfg macro for OS conditional compilation

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod platform_specific;
 #[cfg(target_os = "windows")]
 use platform_specific::windows;
 
+#[cfg(target_os = "linux")]
 use platform_specific::linux;
 
 use serde::{Deserialize, Serialize};
@@ -67,7 +68,7 @@ pub fn check_mod_version_number(path_to_mod_folder: String) -> Result<String, an
 // I intend to add more linux related stuff to check here, so making a func
 // for now tho it only checks `ldd --version`
 // - salmon
-
+#[cfg(target_os = "linux")]
 pub fn linux_checks_librs() -> Result<(), String> {
     // Perform various checks in terms of Linux compatibility
     // Return early with error message if a check fails

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -142,12 +142,16 @@ async fn is_debug_mode() -> bool {
 #[tauri::command]
 /// Returns true if linux compatible
 async fn linux_checks() -> Result<(), String> {
-    // Early return if Windows
-    if get_host_os() == "windows" {
-        return Err("Not available on Windows".to_string());
+    // Different behaviour depending on OS
+    #[cfg(target_os = "windows")]
+    {
+        Err("Not available on Windows".to_string())
     }
 
-    linux_checks_librs()
+    #[cfg(target_os = "linux")]
+    {
+        linux_checks_librs()
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -143,6 +143,8 @@ async fn is_debug_mode() -> bool {
 /// Returns true if linux compatible
 async fn linux_checks() -> Result<(), String> {
     // Different behaviour depending on OS
+    // MacOS is missing as it is not a target
+    // in turn this means this application will not build on MacOS.
     #[cfg(target_os = "windows")]
     {
         Err("Not available on Windows".to_string())

--- a/src-tauri/src/platform_specific/mod.rs
+++ b/src-tauri/src/platform_specific/mod.rs
@@ -1,4 +1,5 @@
 #[cfg(target_os = "windows")]
 pub mod windows;
 
+#[cfg(target_os = "linux")]
 pub mod linux;


### PR DESCRIPTION
Makes sure that Windows/Linux specific functions are only compiled on their respective OS.

Will also help with reducing diff of #180 