### PR TITLE
build: Separate zips for artifacts for Windows and Linux

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -112,10 +112,12 @@ jobs:
     - name: Upload Linux artifact
       uses: actions/upload-artifact@v2
       with:
+        name: linux-artifacts
         path: |
           src-tauri/target/release/bundle/appimage/*
     - name: Upload Windows artifact
       uses: actions/upload-artifact@v2
       with:
+        name: windows-artifacts
         path: |
           src-tauri/target/release/bundle/msi/*

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -109,9 +109,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-    - name: upload build artifact
+    - name: Upload Linux artifact
       uses: actions/upload-artifact@v2
       with:
         path: |
           src-tauri/target/release/bundle/appimage/*
+    - name: Upload Windows artifact
+      uses: actions/upload-artifact@v2
+      with:
+        path: |
           src-tauri/target/release/bundle/msi/*


### PR DESCRIPTION
Splits up the Windows and Linux artifacts into separate zip folders.

This is especially useful for testing Windows builds as the Linux ones are huge due to being an AppImage. Windows is tiny (7MB) in comparison and as such this means when testing CI build on Windows with this PR one goes from downloading 300MB (Windows + Linux files) to just 7MB (only Windows files).

![image](https://user-images.githubusercontent.com/40122905/221203499-81c738a1-5be3-4d70-8737-2d1eb61b9b31.png)
