### PR TITLE
build: Add Volar to recommended vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "tauri-apps.tauri-vscode",
-        "rust-lang.rust-analyzer"
+        "rust-lang.rust-analyzer",
+        "vue.volar"
     ]
 }


### PR DESCRIPTION
Adds `vue.Volar` to list of recommended vscode extensions. This should have been there already from the get-go tbh ^^