### PR TITLE
Upload Windows `.pdb`

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -121,3 +121,4 @@ jobs:
         name: windows-artifacts
         path: |
           src-tauri/target/release/bundle/msi/*
+          src-tauri/target/release/app.pdb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
         path: |
           src-tauri/target/release/bundle/appimage/*AppImage*
           src-tauri/target/release/bundle/msi/*msi*
+          src-tauri/target/release/app.pdb
     - name: Release
       uses: softprops/action-gh-release@v1
       with:


### PR DESCRIPTION
Upload Windows debug symbols which are stored in `.pdb` file to artifacts.

This is done as part of an attempt to solve #166