### PR TITLE
chore: Bump libthermite to 0.5.3

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1864,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "libthermite"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ab0312cd1bab244b8b1abd8a0f48b771d4591d4521344468e91a26d6d9fad0"
+checksum = "0d8ef144beaf1e683b0ccb2e6e3e14d1e6a8f29e28be3c4fc93376539b28fe97"
 dependencies = [
  "json5",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ steamlocate = "1.0.2"
 # Error messages
 anyhow = "1.0"
 # libthermite for Northstar/mod install handling
-libthermite = "0.5.2"
+libthermite = "0.5.3"
 # zip stuff
 zip = "0.6.2"
 # Regex


### PR DESCRIPTION
This adds a change needed for making progressbar work on Northstar/mod download.