### PR TITLE
Add buttons to download PRs

### DIFF
--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -277,7 +277,8 @@ fn get_mods_download_link(pull_request: PullsApiResponseElement) -> Result<Strin
 }
 
 /// Gets `nightly.link` artifact download link of a launcher PR
-async fn get_launcher_download_link(
+#[tauri::command]
+pub async fn get_launcher_download_link(
     pull_request: PullsApiResponseElement,
 ) -> Result<String, String> {
     // Iterate over the first 10 pages of

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,7 +15,9 @@ use app::{
 };
 
 mod github;
-use github::pull_requests::{apply_launcher_pr, apply_mods_pr, get_pull_requests_wrapper};
+use github::pull_requests::{
+    apply_launcher_pr, apply_mods_pr, get_launcher_download_link, get_pull_requests_wrapper,
+};
 use github::release_notes::{
     check_is_flightcore_outdated, get_newest_flightcore_version, get_northstar_release_notes,
 };
@@ -119,6 +121,7 @@ fn main() {
             get_pull_requests_wrapper,
             apply_launcher_pr,
             apply_mods_pr,
+            get_launcher_download_link
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-vue/src/components/PullRequestsSelector.vue
+++ b/src-vue/src/components/PullRequestsSelector.vue
@@ -56,8 +56,6 @@
 import { defineComponent } from 'vue'
 import { PullRequestType } from '../../../src-tauri/bindings/PullRequestType';
 import { PullsApiResponseElement } from '../../../src-tauri/bindings/PullsApiResponseElement';
-import { invoke } from "@tauri-apps/api";
-import { ElNotification } from "element-plus";
 
 export default defineComponent({
     name: 'PullRequestsSelector',

--- a/src-vue/src/components/PullRequestsSelector.vue
+++ b/src-vue/src/components/PullRequestsSelector.vue
@@ -3,18 +3,12 @@
         <el-collapse @change="onChange">
             <el-collapse-item title="Launcher PRs" name="1">
                 <p v-if="pull_requests_launcher.length === 0">
-                    <el-progress
-                        :show-text="false"
-                        :percentage="100"
-                        status="warning"
-                        :indeterminate="true"
-                        :duration="1"
-                        style="margin: 15px"
-                    />
+                    <el-progress :show-text="false" :percentage="100" status="warning" :indeterminate="true" :duration="1"
+                        style="margin: 15px" />
                 </p>
-                <el-card v-else shadow="hover" v-for="pull_request in pull_requests_launcher"
-                    v-bind:key="pull_request.url">
+                <el-card v-else shadow="hover" v-for="pull_request in pull_requests_launcher" v-bind:key="pull_request.url">
                     <el-button type="primary" @click="installLauncherPR(pull_request)">Install</el-button>
+                    <el-button type="primary" @click="downloadLauncherPR(pull_request)">Download</el-button>
                     <a target="_blank" :href="pull_request.html_url">
                         {{ pull_request.number }}: {{ pull_request.title }}
                     </a>
@@ -30,18 +24,13 @@
                     </el-alert>
                 </div>
                 <p v-if="pull_requests_mods.length === 0">
-                    <el-progress
-                        :show-text="false"
-                        :percentage="100"
-                        status="warning"
-                        :indeterminate="true"
-                        :duration="1"
-                        style="margin: 15px"
-                    />
+                    <el-progress :show-text="false" :percentage="100" status="warning" :indeterminate="true" :duration="1"
+                        style="margin: 15px" />
                 </p>
                 <el-card v-else shadow="hover" v-for="pull_request in pull_requests_mods" v-bind:key="pull_request.url">
                     <el-button type="primary" @click="installModsPR(pull_request)">Install</el-button>
-                    <a target="_blank" :href="`https://github.com/${pull_request.head.repo.full_name}/archive/refs/heads/${pull_request.head.ref}.zip`">
+                    <a target="_blank"
+                        :href="`https://github.com/${pull_request.head.repo.full_name}/archive/refs/heads/${pull_request.head.ref}.zip`">
                         <el-button type="primary">Download</el-button>
                     </a>
                     <a target="_blank" :href="pull_request.html_url">
@@ -57,7 +46,7 @@
 import { defineComponent } from 'vue'
 import { PullRequestType } from '../../../src-tauri/bindings/PullRequestType';
 import { PullsApiResponseElement } from '../../../src-tauri/bindings/PullsApiResponseElement';
-import { invoke } from "@tauri-apps/api";
+import { invoke, shell } from "@tauri-apps/api";
 import { ElNotification } from "element-plus";
 
 export default defineComponent({
@@ -82,6 +71,9 @@ export default defineComponent({
         },
         async getPullRequests(pull_request_type: PullRequestType) {
             this.$store.commit('getPullRequests', pull_request_type);
+        },
+        async downloadLauncherPR(pull_request: PullsApiResponseElement) {
+            this.$store.commit('downloadLauncherPR', pull_request);
         },
         async installLauncherPR(pull_request: PullsApiResponseElement) {
             this.$store.commit('installLauncherPR', pull_request);

--- a/src-vue/src/components/PullRequestsSelector.vue
+++ b/src-vue/src/components/PullRequestsSelector.vue
@@ -3,10 +3,17 @@
         <el-collapse @change="onChange">
             <el-collapse-item title="Launcher PRs" name="1">
                 <p v-if="pull_requests_launcher.length === 0">
-                    <el-progress :show-text="false" :percentage="100" status="warning" :indeterminate="true" :duration="1"
-                        style="margin: 15px" />
+                    <el-progress
+                        :show-text="false"
+                        :percentage="100"
+                        status="warning"
+                        :indeterminate="true"
+                        :duration="1"
+                        style="margin: 15px"
+                    />
                 </p>
-                <el-card v-else shadow="hover" v-for="pull_request in pull_requests_launcher" v-bind:key="pull_request.url">
+                <el-card v-else shadow="hover" v-for="pull_request in pull_requests_launcher"
+                    v-bind:key="pull_request.url">
                     <el-button type="primary" @click="installLauncherPR(pull_request)">Install</el-button>
                     <el-button type="primary" @click="downloadLauncherPR(pull_request)">Download</el-button>
                     <a target="_blank" :href="pull_request.html_url">
@@ -24,8 +31,14 @@
                     </el-alert>
                 </div>
                 <p v-if="pull_requests_mods.length === 0">
-                    <el-progress :show-text="false" :percentage="100" status="warning" :indeterminate="true" :duration="1"
-                        style="margin: 15px" />
+                    <el-progress
+                        :show-text="false"
+                        :percentage="100"
+                        status="warning"
+                        :indeterminate="true"
+                        :duration="1"
+                        style="margin: 15px"
+                    />
                 </p>
                 <el-card v-else shadow="hover" v-for="pull_request in pull_requests_mods" v-bind:key="pull_request.url">
                     <el-button type="primary" @click="installModsPR(pull_request)">Install</el-button>

--- a/src-vue/src/components/PullRequestsSelector.vue
+++ b/src-vue/src/components/PullRequestsSelector.vue
@@ -29,10 +29,7 @@
                 </p>
                 <el-card v-else shadow="hover" v-for="pull_request in pull_requests_mods" v-bind:key="pull_request.url">
                     <el-button type="primary" @click="installModsPR(pull_request)">Install</el-button>
-                    <a target="_blank"
-                        :href="`https://github.com/${pull_request.head.repo.full_name}/archive/refs/heads/${pull_request.head.ref}.zip`">
-                        <el-button type="primary">Download</el-button>
-                    </a>
+                    <el-button type="primary" @click="downloadModsPR(pull_request)">Download</el-button>
                     <a target="_blank" :href="pull_request.html_url">
                         {{ pull_request.number }}: {{ pull_request.title }}
                     </a>
@@ -74,6 +71,9 @@ export default defineComponent({
         },
         async downloadLauncherPR(pull_request: PullsApiResponseElement) {
             this.$store.commit('downloadLauncherPR', pull_request);
+        },
+        async downloadModsPR(pull_request: PullsApiResponseElement) {
+            this.$store.commit('downloadModsPR', pull_request);
         },
         async installLauncherPR(pull_request: PullsApiResponseElement) {
             this.$store.commit('installLauncherPR', pull_request);

--- a/src-vue/src/components/PullRequestsSelector.vue
+++ b/src-vue/src/components/PullRequestsSelector.vue
@@ -56,7 +56,7 @@
 import { defineComponent } from 'vue'
 import { PullRequestType } from '../../../src-tauri/bindings/PullRequestType';
 import { PullsApiResponseElement } from '../../../src-tauri/bindings/PullsApiResponseElement';
-import { invoke, shell } from "@tauri-apps/api";
+import { invoke } from "@tauri-apps/api";
 import { ElNotification } from "element-plus";
 
 export default defineComponent({

--- a/src-vue/src/components/PullRequestsSelector.vue
+++ b/src-vue/src/components/PullRequestsSelector.vue
@@ -41,6 +41,9 @@
                 </p>
                 <el-card v-else shadow="hover" v-for="pull_request in pull_requests_mods" v-bind:key="pull_request.url">
                     <el-button type="primary" @click="installModsPR(pull_request)">Install</el-button>
+                    <a target="_blank" :href="`https://github.com/${pull_request.head.repo.full_name}/archive/refs/heads/${pull_request.head.ref}.zip`">
+                        <el-button type="primary">Download</el-button>
+                    </a>
                     <a target="_blank" :href="pull_request.html_url">
                         {{ pull_request.number }}: {{ pull_request.title }}
                     </a>

--- a/src-vue/src/plugins/modules/pull_requests.ts
+++ b/src-vue/src/plugins/modules/pull_requests.ts
@@ -1,5 +1,5 @@
 import { ElNotification } from "element-plus";
-import { invoke } from "@tauri-apps/api";
+import { invoke, shell } from "@tauri-apps/api";
 import { PullsApiResponseElement } from "../../../../src-tauri/bindings/PullsApiResponseElement";
 import { PullRequestType } from '../../../../src-tauri/bindings/PullRequestType';
 import { store } from "../store";
@@ -31,6 +31,21 @@ export const pullRequestModule = {
                         default:
                             console.error("We should never end up here");
                     }
+                })
+                .catch((error) => {
+                    ElNotification({
+                        title: 'Error',
+                        message: error,
+                        type: 'error',
+                        position: 'bottom-right'
+                    });
+                });
+        },
+        async downloadLauncherPR(state: PullRequestStoreState, pull_request: PullsApiResponseElement) {
+            await invoke<string>("get_launcher_download_link", { pullRequest: pull_request })
+                .then((url) => {
+                    // Open URL in default HTTPS handler (i.e. default browser)
+                    shell.open(url);
                 })
                 .catch((error) => {
                     ElNotification({

--- a/src-vue/src/plugins/modules/pull_requests.ts
+++ b/src-vue/src/plugins/modules/pull_requests.ts
@@ -56,6 +56,10 @@ export const pullRequestModule = {
                     });
                 });
         },
+        async downloadModsPR(state: PullRequestStoreState, pull_request: PullsApiResponseElement) {
+            let url = `https://github.com/${pull_request.head.repo.full_name}/archive/refs/heads/${pull_request.head.ref}.zip`
+            shell.open(url);
+        },
         async installLauncherPR(state: PullRequestStoreState, pull_request: PullsApiResponseElement) {
             // Send notification telling the user to wait for the process to finish
             const notification = ElNotification({


### PR DESCRIPTION
Adds buttons to just download PR instead of installing them.
In both cases (Launcher and Mods) the button simply opens the download link in the user's default browser.

Idea for feature was conceived in discussion with @EladNLG where they mentioned that grabbing launcher download link is cumbersome to do.

Rendered:
<!-- ![image](https://user-images.githubusercontent.com/40122905/223276627-97131684-22e3-4a46-b0ef-cc6023d9baec.png) -->

![image](https://user-images.githubusercontent.com/40122905/226312132-8f0e53b2-7472-46eb-8333-02bf3bd45d1e.png)


Closes #201