### PR TITLE
build: Upload Windows pdb to Sentry via CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,18 @@ jobs:
           src-tauri/target/release/bundle/appimage/*AppImage*
           src-tauri/target/release/bundle/msi/*msi*
           src-tauri/target/release/app.pdb
+    - name: Install sentry-cli (Windows only)
+      if: matrix.platform == 'windows-latest'
+      run: |
+        curl --location --output sentry-cli.exe "https://release-registry.services.sentry.io/apps/sentry-cli/latest?response=download&arch=x86_64&platform=Windows&package=sentry-cli"
+    - name: Run sentry-cli to upload pdb (Windows only)
+      if: matrix.platform == 'windows-latest'
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: northstar-kv
+        SENTRY_PROJECT: flightcore
+      run: |
+        ./sentry-cli.exe upload-dif --wait src-tauri/target/release/app.pdb
     - name: Release
       uses: softprops/action-gh-release@v1
       with:


### PR DESCRIPTION
Previously, I would have to manually upload `.pdb`s to Sentry manually myself after every release. Obviously doing things manually is stupid so this adds some CI steps to upload the Windows debug symbols to sentry.io via CI.

![image](https://user-images.githubusercontent.com/40122905/223595945-68cef283-ddd0-40e3-b835-23d996a28dd6.png)
(top one is the newest uploaded in a test run)

For successful test run see https://github.com/GeckoEidechse/Temp-FlightCore/actions/runs/4356663525/jobs/7614981650#step:11:16
(this took way to many attempts, the failed step in CI after is expected cause the repo is a fork with some changes for faster testing)

