### PR TITLE
feat: Add some breadcrumbs printing install path

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 use anyhow::{anyhow, Context, Result};
+use sentry::{add_breadcrumb, Breadcrumb, Level};
 
 mod northstar;
 
@@ -229,6 +230,14 @@ pub async fn install_northstar(
         .find(|f| f.name.to_lowercase() == northstar_package_name.to_lowercase())
         .ok_or_else(|| panic!("Couldn't find Northstar on thunderstore???"))
         .unwrap();
+
+    // Breadcrumb for sentry to debug crash
+    add_breadcrumb(Breadcrumb {
+        // category: Some("auth".into()),
+        message: Some(format!("Install path \"{}\"", game_path)),
+        level: Level::Info,
+        ..Default::default()
+    });
 
     do_install(
         nmod.versions.get(&nmod.latest).unwrap(),


### PR DESCRIPTION
This will show up in sentry dashboard on crash and will help me solve a thread crash that's caused by Northstar failing to get installed.

![image](https://user-images.githubusercontent.com/40122905/224416646-cae4f9dc-29ef-4e2f-9d81-4a42d4e1bdcb.png)
