### PR TITLE
feat: Move open repair window button to settings

### DIFF
--- a/src-vue/src/views/DeveloperView.vue
+++ b/src-vue/src/views/DeveloperView.vue
@@ -37,9 +37,6 @@
 
             <h3>Repair:</h3>
 
-            <el-button type="primary" @click="createNewWindow">
-                Open Repair window
-            </el-button>
 
             <el-button type="primary" @click="getInstalledMods">
                 Get installed mods
@@ -146,19 +143,6 @@ export default defineComponent({
                     position: 'bottom-right'
                 });
             })
-                .catch((error) => {
-                    ElNotification({
-                        title: 'Error',
-                        message: error,
-                        type: 'error',
-                        position: 'bottom-right'
-                    });
-                });
-        },
-
-        async createNewWindow() {
-            await invoke("open_repair_window")
-                .then((message) => { })
                 .catch((error) => {
                     ElNotification({
                         title: 'Error',

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -32,6 +32,11 @@
                     </el-input>
                 </div>
 
+                <h3>Repair</h3>
+                <el-button type="primary" @click="openRepairWindow">
+                    Open Repair window
+                </el-button>
+
                 <h3>About:</h3>
                 <div class="fc_northstar__version" @click="activateDeveloperMode">
                     FlightCore Version: {{ flightcoreVersion === '' ? 'Unknown version' : `${flightcoreVersion}` }}
@@ -53,6 +58,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ElNotification } from 'element-plus';
+import { invoke } from "@tauri-apps/api";
 import { ReleaseCanal } from "../utils/ReleaseCanal";
 import { Store } from 'tauri-plugin-store-api';
 const persistentStore = new Store('flight-core-settings.json');
@@ -109,7 +115,19 @@ export default defineComponent({
         },
         async updateGamePath() {
             this.$store.commit('updateGamePath');
-        }
+        },
+        async openRepairWindow() {
+            await invoke("open_repair_window")
+                .then((message) => { })
+                .catch((error) => {
+                    ElNotification({
+                        title: 'Error',
+                        message: error,
+                        type: 'error',
+                        position: 'bottom-right'
+                    });
+                });
+        },
     },
     mounted() {
         document.querySelector('input')!.disabled = true;


### PR DESCRIPTION
Moving the button from DeveloperView to Settings means that it's now accessible to the end-user, essentially "releasing" that feature ^^

![image](https://user-images.githubusercontent.com/40122905/224563153-e196973c-312e-45cb-bf24-93f6834cb474.png)
