### PR TITLE
fix: Add error handling if default EA App path

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -249,7 +249,8 @@ pub async fn install_northstar(
         Err(err) => {
             if game_path
                 .to_lowercase()
-                .contains(&r#"C:\Program Files\"#.to_lowercase()) // default is `C:\Program Files\EA Games\Titanfall2`
+                .contains(&r#"C:\Program Files\"#.to_lowercase())
+            // default is `C:\Program Files\EA Games\Titanfall2`
             {
                 return Err(
                     "Cannot install to default EA App install path, please move Titanfall2 to a different install location.".to_string(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -239,12 +239,26 @@ pub async fn install_northstar(
         ..Default::default()
     });
 
-    do_install(
+    match do_install(
         nmod.versions.get(&nmod.latest).unwrap(),
         std::path::Path::new(game_path),
     )
     .await
-    .unwrap();
+    {
+        Ok(_) => (),
+        Err(err) => {
+            if game_path
+                .to_lowercase()
+                .contains(&r#"C:\Program Files\EA Games\Titanfall2"#.to_lowercase())
+            {
+                return Err(
+                    "Cannot install to default EA App install path, please move Titanfall2 to a different install location.".to_string(),
+                );
+            } else {
+                return Err(err.to_string());
+            }
+        }
+    }
 
     Ok(nmod.latest.clone())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -249,7 +249,7 @@ pub async fn install_northstar(
         Err(err) => {
             if game_path
                 .to_lowercase()
-                .contains(&r#"C:\Program Files\EA Games\Titanfall2"#.to_lowercase())
+                .contains(&r#"C:\Program Files\"#.to_lowercase()) // default is `C:\Program Files\EA Games\Titanfall2`
             {
                 return Err(
                     "Cannot install to default EA App install path, please move Titanfall2 to a different install location.".to_string(),


### PR DESCRIPTION
We cannot install to `C:\Program Files\EA Games\Titanfall2` cause Windows™
As such if install fails we check for that path and show according error message.

I would kinda also wanna add a link to wiki but AFAIK links won't render clickable so it's not really super helpful...

Closes #171