### PR TITLE
refactor: Fix PR downloads permission issue

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "tokio",
  "ts-rs",
  "zip",
+ "zip-extract",
 ]
 
 [[package]]
@@ -5034,6 +5035,17 @@ dependencies = [
  "sha1",
  "time 0.3.20",
  "zstd",
+]
+
+[[package]]
+name = "zip-extract"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb654964c003959ed64cbd0d7b329bcdcbd9690facd50c8617748d3622543972"
+dependencies = [
+ "log",
+ "thiserror",
+ "zip",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,6 +54,8 @@ chrono = "0.4.23"
 ts-rs = "6.1"
 # const formatting
 const_format = "0.2.30"
+# Extracting zip files easily
+zip-extract = "0.1.2"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -220,9 +220,6 @@ pub async fn apply_launcher_pr(
     // Exit early if wrong game path
     check_is_valid_game_path(game_install_path)?;
 
-    // let path = std::env::current_dir().unwrap();
-    // return Err(format!("The current directory is {}", path.display()));
-
     // get download link
     let download_url = get_launcher_download_link(pull_request.clone()).await?;
 

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -322,8 +322,17 @@ pub async fn apply_mods_pr(
         }
     };
 
-    let target_dir = std::path::PathBuf::from(format!(
+    // Create profile folder
+    match std::fs::create_dir_all(format!(
         "{}/R2Northstar-PR-test-managed-folder",
+        game_install_path
+    )) {
+        Ok(()) => (),
+        Err(err) => return Err(err.to_string()),
+    }
+
+    let target_dir = std::path::PathBuf::from(format!(
+        "{}/R2Northstar-PR-test-managed-folder/mods",
         game_install_path
     )); // Doesn't need to exist
     match zip_extract::extract(io::Cursor::new(archive), &target_dir, true) {

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -314,11 +314,18 @@ pub async fn apply_launcher_pr(
     // return Err(format!("The current directory is {}", path.display()));
 
     // get download link
-    let download_url = get_launcher_download_link(pull_request).await?;
+    let download_url = get_launcher_download_link(pull_request.clone()).await?;
 
-    // download
-    let download_directory = format!("{}/___flightcore-temp-download-dir/", game_install_path);
-    match std::fs::create_dir_all(download_directory.clone()) {
+    let archive = match download_zip_into_memory(download_url).await {
+        Ok(archive) => archive,
+        Err(err) => return Err(err.to_string()),
+    };
+
+    let extract_directory = format!(
+        "{}/___flightcore-temp-download-dir/launcher-pr-{}",
+        game_install_path, pull_request.number
+    );
+    match std::fs::create_dir_all(extract_directory.clone()) {
         Ok(_) => (),
         Err(err) => {
             return Err(format!(
@@ -328,33 +335,38 @@ pub async fn apply_launcher_pr(
         }
     };
 
-    match download_zip(download_url, download_directory.clone()).await {
-        Ok(_) => (),
-        Err(err) => return Err(err.to_string()),
-    };
+    let target_dir = std::path::PathBuf::from(extract_directory.clone()); // Doesn't need to exist
+    zip_extract::extract(io::Cursor::new(archive), &target_dir, true).unwrap();
 
-    // extract
-    let zip_extract_folder_name = unzip_launcher_zip(format!(
-        "{}/ns-dev-test-helper-temp-pr-files.zip",
-        download_directory.clone()
-    ));
-    fs::remove_file(format!(
-        "{}/ns-dev-test-helper-temp-pr-files.zip",
-        download_directory.clone()
-    ))
-    .unwrap();
-
-    // Copy downloaded folder to game install folder
-    match copy_dir_all(zip_extract_folder_name.clone(), game_install_path) {
-        Ok(_) => (),
-        Err(err) => {
-            return Err(format!("Failed copying files: {}", err));
-        }
+    // Copy only necessary files from temp dir
+    // Copy:
+    // - NorthstarLauncher.exe
+    // - Northstar.dll
+    let files_to_copy = vec!["NorthstarLauncher.exe", "Northstar.dll"];
+    for file_name in files_to_copy {
+        let source_file_path = format!("{}/{}", extract_directory, file_name);
+        let destination_file_path = format!("{}/{}", game_install_path, file_name);
+        match std::fs::copy(&source_file_path, &destination_file_path) {
+            Ok(_result) => (),
+            Err(err) => {
+                return Err(format!(
+                    "Failed to copy necessary file {} from temp dir: {}",
+                    file_name, err
+                ))
+            }
+        };
     }
 
-    // Delete old unzipped
-    fs::remove_dir_all(zip_extract_folder_name).unwrap();
-    std::fs::remove_dir_all(download_directory).unwrap();
+    // delete extract directory
+    match std::fs::remove_dir_all(&extract_directory) {
+        Ok(()) => (),
+        Err(err) => {
+            return Err(format!(
+                "Failed to delete temporary download directory: {}",
+                err
+            ))
+        }
+    }
 
     println!("All done with installing launcher PR");
     Ok(())

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -136,6 +136,7 @@ async fn download_zip(download_url: String, location: String) -> Result<(), anyh
     Ok(())
 }
 
+/// Downloads a file from given URL into an array in memory
 async fn download_zip_into_memory(download_url: String) -> Result<Vec<u8>, reqwest::Error> {
     let client = reqwest::Client::builder()
         .user_agent(APP_USER_AGENT)

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -374,17 +374,6 @@ pub async fn apply_mods_pr(
         Err(err) => return Err(err.to_string()),
     };
 
-    let download_directory = format!("{}/___flightcore-temp-download-dir/", game_install_path);
-    match std::fs::create_dir_all(download_directory.clone()) {
-        Ok(_) => (),
-        Err(err) => {
-            return Err(format!(
-                "Failed creating temporary download directory: {}",
-                err
-            ))
-        }
-    };
-
     let archive = match download_zip_into_memory(download_url).await {
         Ok(archive) => archive,
         Err(err) => return Err(err.to_string()),

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -303,19 +303,11 @@ pub async fn apply_mods_pr(
         Err(err) => return Err(err.to_string()),
     };
 
+    let profile_folder = format!("{}/R2Northstar-PR-test-managed-folder", game_install_path);
+
     // Delete previously managed folder
-    if std::fs::remove_dir_all(format!(
-        "{}/R2Northstar-PR-test-managed-folder",
-        game_install_path
-    ))
-    .is_err()
-    {
-        if std::path::Path::new(&format!(
-            "{}/R2Northstar-PR-test-managed-folder",
-            game_install_path
-        ))
-        .exists()
-        {
+    if std::fs::remove_dir_all(profile_folder.clone()).is_err() {
+        if std::path::Path::new(&profile_folder).exists() {
             println!("Failed removing previous dir");
         } else {
             println!("Failed removing folder that doesn't exist. Probably cause first run");
@@ -323,18 +315,12 @@ pub async fn apply_mods_pr(
     };
 
     // Create profile folder
-    match std::fs::create_dir_all(format!(
-        "{}/R2Northstar-PR-test-managed-folder",
-        game_install_path
-    )) {
+    match std::fs::create_dir_all(profile_folder.clone()) {
         Ok(()) => (),
         Err(err) => return Err(err.to_string()),
     }
 
-    let target_dir = std::path::PathBuf::from(format!(
-        "{}/R2Northstar-PR-test-managed-folder/mods",
-        game_install_path
-    )); // Doesn't need to exist
+    let target_dir = std::path::PathBuf::from(format!("{}/mods", profile_folder)); // Doesn't need to exist
     match zip_extract::extract(io::Cursor::new(archive), &target_dir, true) {
         Ok(()) => (),
         Err(err) => {

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -240,7 +240,12 @@ pub async fn apply_launcher_pr(
     };
 
     let target_dir = std::path::PathBuf::from(extract_directory.clone()); // Doesn't need to exist
-    zip_extract::extract(io::Cursor::new(archive), &target_dir, true).unwrap();
+    match zip_extract::extract(io::Cursor::new(archive), &target_dir, true) {
+        Ok(()) => (),
+        Err(err) => {
+            return Err(format!("Failed unzip: {}", err));
+        }
+    };
 
     // Copy only necessary files from temp dir
     // Copy:
@@ -318,8 +323,12 @@ pub async fn apply_mods_pr(
         "{}/R2Northstar-PR-test-managed-folder",
         game_install_path
     )); // Doesn't need to exist
-    zip_extract::extract(io::Cursor::new(archive), &target_dir, true).unwrap();
-
+    match zip_extract::extract(io::Cursor::new(archive), &target_dir, true) {
+        Ok(()) => (),
+        Err(err) => {
+            return Err(format!("Failed unzip: {}", err));
+        }
+    };
     // Add batch file to launch right profile
     add_batch_file(game_install_path);
 

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -1,5 +1,6 @@
 use crate::github::release_notes::fetch_github_releases_api;
 
+use anyhow::anyhow;
 use app::check_is_valid_game_path;
 use app::constants::{APP_USER_AGENT, PULLS_API_ENDPOINT_LAUNCHER, PULLS_API_ENDPOINT_MODS};
 use serde::{Deserialize, Serialize};
@@ -109,12 +110,17 @@ pub async fn check_github_api(url: &str) -> Result<serde_json::Value, Box<dyn st
 }
 
 /// Downloads a file from given URL into an array in memory
-async fn download_zip_into_memory(download_url: String) -> Result<Vec<u8>, reqwest::Error> {
+async fn download_zip_into_memory(download_url: String) -> Result<Vec<u8>, anyhow::Error> {
     let client = reqwest::Client::builder()
         .user_agent(APP_USER_AGENT)
         .build()?;
 
     let response = client.get(download_url).send().await?;
+
+    if !response.status().is_success() {
+        return Err(anyhow!("Request unsuccessful: {}", response.status()));
+    }
+
     let bytes = response.bytes().await?;
     Ok(bytes.to_vec())
 }


### PR DESCRIPTION
Avoids any folder write permission issues by writing into memory and/or temp dir in Titanfall2 folder.

This started out as a small bug fix PR but uncovered a bunch of issues that prompted me to refactor most of the code entirely.



TODO:

- [x] Download Launcher PRs into Titanfall2 dir
- [x] Download Mods PRs into Titanfall2 dir
- [x] Reverify above two
- [x] Compare old and new download code
- [x] Sanity checks

Closes #212 