### PR TITLE
fix: Handle error when Northstar download fails

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -195,7 +195,10 @@ async fn do_install(nmod: &thermite::model::ModVersion, game_path: &std::path::P
     let download_path = format!("{}/{}", download_directory.clone(), filename);
     println!("{}", download_path);
 
-    let nfile = thermite::core::manage::download_file(&nmod.url, download_path).unwrap();
+    let nfile = match thermite::core::manage::download_file(&nmod.url, download_path){
+        Ok(res) => res,
+        Err(err) => return Err(anyhow!("Failed downloading Northstar {}", err)),
+    };
 
     println!("Extracting Northstar...");
     extract(nfile, game_path)?;


### PR DESCRIPTION
In case of download failure return an error message.

Should resolve https://northstar-kv.sentry.io/issues/4014183248/

![image](https://user-images.githubusercontent.com/40122905/226328950-85def312-1fc9-4c76-9fce-2b7c37edf548.png)
