### PR TITLE
fix: Address clippy errors in glibc parsing code

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -80,8 +80,7 @@ pub fn linux_checks_librs() -> Result<(), String> {
         return Err(format!(
             "GLIBC is not version {} or greater",
             min_required_ldd_version
-        )
-        .to_string());
+        ));
     };
 
     // All checks passed

--- a/src-tauri/src/platform_specific/linux.rs
+++ b/src-tauri/src/platform_specific/linux.rs
@@ -14,10 +14,10 @@ pub fn check_glibc_v() -> f32 {
     let lddvl: Vec<&str> = lddva.split('\n').collect();
     let lddvlo = &lddvl[0];
     let reg = Regex::new(r"(2.\d{2}$)").unwrap();
-    for caps in reg.captures_iter(lddvlo) {
+    if let Some(caps) = reg.captures_iter(lddvlo).next() {
         return caps.get(1).unwrap().as_str().parse::<f32>().unwrap(); // theres prolly a better way ijdk how tho
     }
-    return 0.0; // this shouldnt ever be reached but it has to be here
+    0.0 // this shouldnt ever be reached but it has to be here
 }
 
 /*


### PR DESCRIPTION
Removes 3 errors/warnings found by running `cargo clippy`. This is basically just code refactoring.
Tested to still work as expected on Ubuntu 22.04

Partially addresses #225 