### PR TITLE
fix: Address regression around persistent store

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -145,6 +145,7 @@ const persistentStore = new Store('flight-core-settings.json');
 
 // Save change in persistent store
 await persistentStore.set('northstar-release-canal', { value: "NorthstarReleasecandidate" });
+await persistentStore.save(); // explicit save to disk
 
 // Grab Northstar release canal value from store if exists
 var persistent_northstar_release_canal = (await persistentStore.get('northstar-release-canal')) as any;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3969,8 +3969,8 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-store"
-version = "0.0.0"
-source = "git+https://github.com/tauri-apps/tauri-plugin-store?rev=9bd993aa67766596638bbfd91e79a1bf8f632014#9bd993aa67766596638bbfd91e79a1bf8f632014"
+version = "0.1.0"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=dev#5a6abd3203dc94c38f96d0c4bf7ecbef399f8c25"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-store"
 version = "0.1.0"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=dev#5a6abd3203dc94c38f96d0c4bf7ecbef399f8c25"
+source = "git+https://github.com/tauri-apps/plugins-workspace?rev=5a6abd3203dc94c38f96d0c4bf7ecbef399f8c25#5a6abd3203dc94c38f96d0c4bf7ecbef399f8c25"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,7 +43,7 @@ sysinfo = "0.26.2"
 # HTTP requests
 reqwest = { version = "0.11", features = ["blocking"] }
 # Persistent store for settings
-tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev" }
+tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", rev = "5a6abd3203dc94c38f96d0c4bf7ecbef399f8c25" }
 # JSON5 parsing support (allows comments in JSON)
 json5 = "0.4.1"
 # Async recursion for recursive mod install

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,7 +43,7 @@ sysinfo = "0.26.2"
 # HTTP requests
 reqwest = { version = "0.11", features = ["blocking"] }
 # Persistent store for settings
-tauri-plugin-store = { git = "https://github.com/tauri-apps/tauri-plugin-store", rev = "9bd993aa67766596638bbfd91e79a1bf8f632014" }
+tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev" }
 # JSON5 parsing support (allows comments in JSON)
 json5 = "0.4.1"
 # Async recursion for recursive mod install

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -38,7 +38,6 @@ mod thunderstore;
 use thunderstore::query_thunderstore_packages_api;
 
 use tauri::{Manager, Runtime};
-use tauri_plugin_store::PluginBuilder;
 use tokio::time::sleep;
 
 #[derive(Default)]
@@ -65,7 +64,7 @@ fn main() {
     ));
 
     tauri::Builder::default()
-        .plugin(PluginBuilder::default().build())
+        .plugin(tauri_plugin_store::Builder::default().build())
         .setup(|app| {
             let app_handle = app.app_handle();
             tauri::async_runtime::spawn(async move {

--- a/src-vue/package-lock.json
+++ b/src-vue/package-lock.json
@@ -11,7 +11,7 @@
         "@element-plus/icons-vue": "^2.0.9",
         "element-plus": "^2.2.17",
         "marked": "^4.1.1",
-        "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store",
+        "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#9bd993aa67766596638bbfd91e79a1bf8f632014",
         "vue": "^3.2.37",
         "vue-router": "^4.1.5",
         "vuex": "^4.0.2"

--- a/src-vue/package-lock.json
+++ b/src-vue/package-lock.json
@@ -11,7 +11,7 @@
         "@element-plus/icons-vue": "^2.0.9",
         "element-plus": "^2.2.17",
         "marked": "^4.1.1",
-        "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#9bd993aa67766596638bbfd91e79a1bf8f632014",
+        "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store",
         "vue": "^3.2.37",
         "vue-router": "^4.1.5",
         "vuex": "^4.0.2"

--- a/src-vue/package-lock.json
+++ b/src-vue/package-lock.json
@@ -11,7 +11,7 @@
         "@element-plus/icons-vue": "^2.0.9",
         "element-plus": "^2.2.17",
         "marked": "^4.1.1",
-        "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#dev",
+        "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#9bd993aa67766596638bbfd91e79a1bf8f632014",
         "vue": "^3.2.37",
         "vue-router": "^4.1.5",
         "vuex": "^4.0.2"
@@ -107,11 +107,11 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-1.2.0.tgz",
-      "integrity": "sha512-lsI54KI6HGf7VImuf/T9pnoejfgkNoXveP14pVV7XarrQ46rOejIVJLFqHI9sRReJMGdh2YuCoI3cc/yCWCsrw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-n13pIqdPd3KtaMmmAcrU7BTfdMtIlGNnfZD0dNX8L4p8dgmuNyikm6JAA+yCpl9gqq6I8x5cV2Y0muqdgD0cWw==",
       "engines": {
-        "node": ">= 14.6.0",
+        "node": ">= 12.22.0",
         "npm": ">= 6.6.0",
         "yarn": ">= 1.19.1"
       },
@@ -1064,12 +1064,19 @@
       }
     },
     "node_modules/tauri-plugin-store-api": {
-      "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/tauri-apps/tauri-plugin-store.git#916165e4e4ad9821095584dc02ecd9c295cc9971",
-      "license": "MIT or APACHE-2.0",
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/tauri-apps/tauri-plugin-store.git#9bd993aa67766596638bbfd91e79a1bf8f632014",
+      "integrity": "sha512-X0cDDcEVLY2X8qCLISgAjzuBKDn7bJkj4S7LnXbEPFbPRe+NzhmFGHSAdFCuQuPzQYjmrVg18mZx9NAg4GBHag==",
+      "license": "MIT",
       "dependencies": {
-        "@tauri-apps/api": "^1.2.0"
+        "@tauri-apps/api": "1.1.0",
+        "tslib": "2.4.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/typescript": {
       "version": "4.9.5",

--- a/src-vue/package.json
+++ b/src-vue/package.json
@@ -12,7 +12,7 @@
     "@element-plus/icons-vue": "^2.0.9",
     "element-plus": "^2.2.17",
     "marked": "^4.1.1",
-    "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#9bd993aa67766596638bbfd91e79a1bf8f632014",
+    "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store",
     "vue": "^3.2.37",
     "vue-router": "^4.1.5",
     "vuex": "^4.0.2"

--- a/src-vue/package.json
+++ b/src-vue/package.json
@@ -12,7 +12,7 @@
     "@element-plus/icons-vue": "^2.0.9",
     "element-plus": "^2.2.17",
     "marked": "^4.1.1",
-    "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store",
+    "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#9bd993aa67766596638bbfd91e79a1bf8f632014",
     "vue": "^3.2.37",
     "vue-router": "^4.1.5",
     "vuex": "^4.0.2"

--- a/src-vue/package.json
+++ b/src-vue/package.json
@@ -12,7 +12,7 @@
     "@element-plus/icons-vue": "^2.0.9",
     "element-plus": "^2.2.17",
     "marked": "^4.1.1",
-    "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#dev",
+    "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#9bd993aa67766596638bbfd91e79a1bf8f632014",
     "vue": "^3.2.37",
     "vue-router": "^4.1.5",
     "vuex": "^4.0.2"

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -143,6 +143,7 @@ export const store = createStore<FlightCoreStore>({
 
                     // Save change in persistent store
                     await persistentStore.set('game-install', { value: game_install });
+                    await persistentStore.save(); // explicit save to disk
 
                     // Check for Northstar install
                     store.commit('checkNorthstarUpdates');
@@ -307,6 +308,7 @@ export const store = createStore<FlightCoreStore>({
 
             // Save change in persistent store
             await persistentStore.set('northstar-release-canal', { value: state.northstar_release_canal });
+            await persistentStore.save(); // explicit save to disk
 
             // Update current state so that update check etc can be performed
             store.commit("checkNorthstarUpdates");
@@ -407,6 +409,7 @@ async function _initializeApp(state: any) {
 
         // Save change in persistent store
         await persistentStore.set('game-install', { value: typedResult });
+        await persistentStore.save(); // explicit save to disk
 
         // Update UI store
         state.game_path = typedResult.game_path;

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -78,9 +78,10 @@ export default defineComponent({
             get(): boolean {
                 return this.$store.state.enableReleasesSwitch;
             },
-            set(value: boolean): void {
+            async set(value: boolean): Promise<void> {
                 this.$store.state.enableReleasesSwitch = value;
                 persistentStore.set('northstar-releases-switching', { value });
+                await persistentStore.save(); // explicit save to disk
 
                 // When disabling switch, we switch release canal to stable release, to avoid users being
                 // stuck with release candidate after disabling release switching.
@@ -93,9 +94,10 @@ export default defineComponent({
             get(): number {
                 return this.$store.state.mods_per_page;
             },
-            set(value: number) {
+            async set(value: number) {
                 this.$store.state.mods_per_page = value;
                 persistentStore.set('thunderstore-mods-per-page', { value });
+                await persistentStore.save(); // explicit save to disk
             }
         }
     },


### PR DESCRIPTION
As discussed in #233 saving persistent store was broken some time ago. Calling `save` explicitly  seems to resolve it.

For good measure, also bumped plugin-store version and updated pulled dependency as [described in their README](https://github.com/tauri-apps/plugins-workspace/tree/dev/plugins/store).

- Closes #233 
- Unblocks #182 