### PR TITLE
fix: Remove unnecessary `.to_string()`

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -385,7 +385,7 @@ pub fn get_enabled_mods(game_install: GameInstall) -> Result<serde_json::value::
     // Parse JSON
     let res: serde_json::Value = match serde_json::from_str(&data) {
         Ok(result) => result,
-        Err(err) => return Err(format!("Failed to read JSON due to: {}", err.to_string())),
+        Err(err) => return Err(format!("Failed to read JSON due to: {}", err)),
     };
 
     // Return parsed data

--- a/src-tauri/src/platform_specific/windows.rs
+++ b/src-tauri/src/platform_specific/windows.rs
@@ -18,7 +18,7 @@ pub fn origin_install_location_detection() -> Result<String, anyhow::Error> {
                             return Ok(game_path_str.to_string());
                         }
                         Err(err) => {
-                            println!("{}", err.to_string());
+                            println!("{}", err);
                             continue; // Not a valid game path
                         }
                     }


### PR DESCRIPTION
As pointed out by `cargo clippy`

Partially addresses #225