### PR TITLE
refactor: Replace all `println!()` with log statements

### DIFF
--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -309,9 +309,9 @@ pub async fn apply_mods_pr(
     // Delete previously managed folder
     if std::fs::remove_dir_all(profile_folder.clone()).is_err() {
         if std::path::Path::new(&profile_folder).exists() {
-            println!("Failed removing previous dir");
+            log::error!("Failed removing previous dir");
         } else {
-            println!("Failed removing folder that doesn't exist. Probably cause first run");
+            log::warn!("Failed removing folder that doesn't exist. Probably cause first run");
         }
     };
 
@@ -331,6 +331,6 @@ pub async fn apply_mods_pr(
     // Add batch file to launch right profile
     add_batch_file(game_install_path);
 
-    println!("All done with installing mods PR");
+    log::info!("All done with installing mods PR");
     Ok(())
 }

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -208,7 +208,7 @@ fn add_batch_file(game_install_path: &str) {
 
     match file.write_all(batch_file_content.as_bytes()) {
         Err(why) => panic!("couldn't write to {}: {}", display, why),
-        Ok(_) => println!("successfully wrote to {}", display),
+        Ok(_) => log::info!("successfully wrote to {}", display),
     }
 }
 

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -281,7 +281,7 @@ pub async fn apply_launcher_pr(
         }
     }
 
-    println!("All done with installing launcher PR");
+    log::info!("All done with installing launcher PR");
     Ok(())
 }
 

--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -98,7 +98,7 @@ pub async fn get_northstar_release_notes() -> Result<Vec<ReleaseInfo>, String> {
 
     let release_info_vector: Vec<ReleaseInfo> =
         serde_json::from_str(&res).expect("JSON was not well-formatted");
-    println!("Done checking GitHub API");
+    log::info!("Done checking GitHub API");
 
     return Ok(release_info_vector);
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,18 +191,18 @@ async fn do_install(nmod: &thermite::model::ModVersion, game_path: &std::path::P
     std::fs::create_dir_all(download_directory.clone())?;
 
     let download_path = format!("{}/{}", download_directory.clone(), filename);
-    println!("{download_path}");
+    log::info!("Download path: {download_path}");
 
     let nfile = thermite::core::manage::download_file(&nmod.url, download_path).unwrap();
 
-    println!("Extracting Northstar...");
+    log::info!("Extracting Northstar...");
     extract(nfile, game_path)?;
 
     // Delete old copy
-    println!("Delete temp folder again");
+    log::info!("Delete temp folder again");
     std::fs::remove_dir_all(download_directory).unwrap();
 
-    println!("Done!");
+    log::info!("Done installing Northstar!");
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,10 +102,10 @@ pub fn find_game_install_location() -> Result<GameInstall, String> {
                     };
                     return Ok(game_install);
                 }
-                None => println!("Couldn't locate Titanfall2"),
+                None => log::info!("Couldn't locate Titanfall2 Steam instal"),
             }
         }
-        None => println!("Couldn't locate Steam on this computer!"),
+        None => log::info!("Couldn't locate Steam on this computer!"),
     }
 
     // (On Windows only) try parsing Windows registry for Origin install path
@@ -119,7 +119,7 @@ pub fn find_game_install_location() -> Result<GameInstall, String> {
             return Ok(game_install);
         }
         Err(err) => {
-            println!("{}", err);
+            log::info!("{}", err);
         }
     };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -157,7 +157,7 @@ fn extract(zip_file: std::fs::File, target: &std::path::Path) -> Result<()> {
             );
 
             if (*f.name()).ends_with('/') {
-                println!("Create directory {}", f.name());
+                log::info!("Create directory {}", f.name());
                 std::fs::create_dir_all(target.join(f.name()))
                     .context("Unable to create directory")?;
                 continue;
@@ -171,7 +171,7 @@ fn extract(zip_file: std::fs::File, target: &std::path::Path) -> Result<()> {
                 .truncate(true)
                 .open(&out)?;
 
-            println!("Write file {}", out.display());
+            log::info!("Write file {}", out.display());
 
             std::io::copy(&mut f, &mut outfile).context("Unable to write to file")?;
         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -284,11 +284,11 @@ async fn install_northstar_caller(
     game_path: String,
     northstar_package_name: Option<String>,
 ) -> Result<bool, String> {
-    println!("Running");
+    log::info!("Running");
     match install_northstar(&game_path, northstar_package_name).await {
         Ok(_) => Ok(true),
         Err(err) => {
-            println!("{}", err);
+            log::error!("{}", err);
             Err(err.to_string())
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -266,7 +266,7 @@ async fn verify_install_location(game_path: String) -> bool {
     match check_is_valid_game_path(&game_path) {
         Ok(()) => true,
         Err(err) => {
-            println!("{}", err);
+            log::warn!("{}", err);
             false
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -234,7 +234,7 @@ async fn check_is_northstar_outdated(
     let version_number = match get_northstar_version_number(game_path) {
         Ok(version_number) => version_number,
         Err(err) => {
-            println!("{}", err);
+            log::warn!("{}", err);
             // If we fail to get new version just assume we are up-to-date
             return Err(err.to_string());
         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -300,13 +300,13 @@ async fn update_northstar_caller(
     game_path: String,
     northstar_package_name: Option<String>,
 ) -> Result<bool, String> {
-    println!("Updating");
+    log::info!("Updating Northstar");
 
     // Simply re-run install with up-to-date version for upate
     match install_northstar(&game_path, northstar_package_name).await {
         Ok(_) => Ok(true),
         Err(err) => {
-            println!("{}", err);
+            log::error!("{}", err);
             Err(err.to_string())
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -331,7 +331,7 @@ async fn install_mod_caller(
     match clean_up_download_folder(game_install, false) {
         Ok(()) => Ok(()),
         Err(err) => {
-            println!("Failed to delete download folder due to {}", err);
+            log::info!("Failed to delete download folder due to {}", err);
             // Failure to delete download folder is not an error in mod install
             // As such ignore. User can still force delete if need be
             Ok(())

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -189,7 +189,7 @@ fn parse_installed_mods(game_install: GameInstall) -> Result<Vec<NorthstarMod>, 
         let parsed_mod_json: ModJson = match json5::from_str(&data) {
             Ok(parsed_json) => parsed_json,
             Err(err) => {
-                println!("Failed parsing {} with {}", mod_json_path, err.to_string());
+                log::warn!("Failed parsing {} with {}", mod_json_path, err.to_string());
                 continue;
             }
         };

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -94,8 +94,8 @@ pub fn set_mod_enabled_status(
     let mut res: serde_json::Value = match get_enabled_mods(game_install.clone()) {
         Ok(res) => res,
         Err(err) => {
-            println!("Couldn't parse `enabledmod.json`: {}", err);
-            println!("Rebuilding file.");
+            log::warn!("Couldn't parse `enabledmod.json`: {}", err);
+            log::warn!("Rebuilding file.");
 
             rebuild_enabled_mods_json(game_install.clone())?;
 
@@ -108,7 +108,7 @@ pub fn set_mod_enabled_status(
     // Check if key exists
     if res.get(mod_name.clone()).is_none() {
         // If it doesn't exist, rebuild `enabledmod.json`
-        println!("Value not found in `enabledmod.json`. Rebuilding file");
+        log::info!("Value not found in `enabledmod.json`. Rebuilding file");
         rebuild_enabled_mods_json(game_install.clone())?;
 
         // Then try again

--- a/src-tauri/src/platform_specific/windows.rs
+++ b/src-tauri/src/platform_specific/windows.rs
@@ -18,14 +18,14 @@ pub fn origin_install_location_detection() -> Result<String, anyhow::Error> {
                             return Ok(game_path_str.to_string());
                         }
                         Err(err) => {
-                            println!("{}", err);
+                            log::warn!("{}", err);
                             continue; // Not a valid game path
                         }
                     }
                 }
             }
             Err(err) => {
-                println!("Couldn't find {origin_id}: {err}")
+                log::warn!("Couldn't find {origin_id}: {err}")
             }
         }
     }

--- a/src-tauri/src/thunderstore/mod.rs
+++ b/src-tauri/src/thunderstore/mod.rs
@@ -43,7 +43,7 @@ pub struct ThunderstoreModVersion {
 /// Queries Thunderstore packages API
 #[tauri::command]
 pub async fn query_thunderstore_packages_api() -> Result<Vec<ThunderstoreMod>, String> {
-    println!("Fetching Thunderstore API");
+    log::info!("Fetching Thunderstore API");
 
     // Fetches
     let url = "https://northstar.thunderstore.io/api/v1/package/";


### PR DESCRIPTION
Replace more `println!()` with calls to `log::info`, `log::warn`, etc

Continuation of
- #219
- #223