### PR TITLE
fix: Remove redundant string conversions

### DIFF
--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -68,7 +68,7 @@ pub enum PullRequestType {
 pub async fn get_pull_requests(url: String) -> Result<Vec<PullsApiResponseElement>, String> {
     let json_response = match fetch_github_releases_api(&url).await {
         Ok(result) => result,
-        Err(err) => return Err(err.to_string()),
+        Err(err) => return Err(err),
     };
 
     let pulls_response: Vec<PullsApiResponseElement> = match serde_json::from_str(&json_response) {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -289,7 +289,7 @@ async fn install_northstar_caller(
         Ok(_) => Ok(true),
         Err(err) => {
             log::error!("{}", err);
-            Err(err.to_string())
+            Err(err)
         }
     }
 }
@@ -307,7 +307,7 @@ async fn update_northstar_caller(
         Ok(_) => Ok(true),
         Err(err) => {
             log::error!("{}", err);
-            Err(err.to_string())
+            Err(err)
         }
     }
 }

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -343,10 +343,10 @@ pub async fn fc_download_mod_and_install(
         match fc_download_mod_and_install(game_install.clone(), dep).await {
             Ok(()) => (),
             Err(err) => {
-                if err.to_string() == "Cannot install Northstar as a mod!" {
+                if err == "Cannot install Northstar as a mod!" {
                     continue; // For Northstar as a dependency, we just skip it
                 } else {
-                    return Err(err.to_string());
+                    return Err(err);
                 }
             }
         };


### PR DESCRIPTION
As pointed out by clippy

Partially addresses #225