### PR TITLE
build: Generate release draft on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,11 @@
 name: "release"
 on:
-  release:
-    types: [ created ]
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # Needed to write to GitHub draft release
 
 jobs:
   # Ensure version numbers in various places match up
@@ -76,6 +80,7 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
+        draft: true
         files: |
           src-tauri/target/release/bundle/appimage/*AppImage*
           src-tauri/target/release/bundle/msi/*msi*
@@ -88,10 +93,11 @@ jobs:
     - uses: actions/download-artifact@v3
     - name: Create release file
       run: |
-        python3 scripts/create-release-file.py --version ${{github.event.release.tag_name}}
+        python3 scripts/create-release-file.py --version ${{github.ref_name}}
 
     - name: upload release file
       uses: softprops/action-gh-release@v1
       with:
+        draft: true
         files: |
           latest-release.json


### PR DESCRIPTION
Instead of creating a release and then having CI build the files, have CI build files on tag and then upload them to draft release.

Previously when making a release, this release wouldn't have any files ready until build finished (~30min). During this time the download link on the main README would be broken for example.

This PR changes it to upload files to a release draft and then that release draft can be turned into an actual release, meaning that now there's no time where a GitHub release has no files attached.

This could also be extended in the future to auto-generate release notes like how we do currently from within FligthCore dev tools.

Tested successful run in test repo here: 
https://github.com/GeckoEidechse/Temp-FlightCore/actions/runs/4598431296

and resulting draft (only I have access to that in this case cause personal repo):
https://github.com/GeckoEidechse/Temp-FlightCore/releases/tag/untagged-eda3413aa1a20df8ded7