### PR TITLE
build: Use `npm clean-install`

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -95,8 +95,8 @@ jobs:
       env:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
       run: |
-        npm install
-        cd src-vue && npm install && cd ..
+        npm clean-install
+        cd src-vue && npm clean-install && cd ..
         npm run tauri build
     - uses: tauri-apps/tauri-action@v0
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
       env:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
       run: |
-        npm install
-        cd src-vue && npm install && cd ..
+        npm clean-install
+        cd src-vue && npm clean-install && cd ..
         npm run tauri build
     - uses: tauri-apps/tauri-action@v0
       env:


### PR DESCRIPTION
Use `npm clean-install` instead of `npm install`. `npm clean-install` is recommended over `npm install` for CI pipelines.

https://docs.npmjs.com/cli/v9/commands/npm-ci