### PR TITLE
feat: Persist dev mode

### DIFF
--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -88,17 +88,18 @@ export const store = createStore<FlightCoreStore>({
         checkNorthstarUpdates(state) {
             _get_northstar_version_number(state);
         },
-        async toggleDeveloperMode(state, affectMenuStyle = false) {
+        async toggleDebugMode(_state) {
+            let menu_bar_handle = document.querySelector('#fc_menu-bar');
+            if (menu_bar_handle !== null) {
+                menu_bar_handle.classList.toggle('developer_build');
+            }
+        },
+        async toggleDeveloperMode(state) {
             state.developer_mode = !state.developer_mode;
 
             // Reset tab when closing dev mode.
             if (!state.developer_mode) {
                 store.commit('updateCurrentTab', Tabs.PLAY);
-            }
-
-            let menu_bar_handle = document.querySelector('#fc_menu-bar');
-            if (affectMenuStyle && menu_bar_handle !== null) {
-                menu_bar_handle.classList.toggle('developer_build');
             }
 
             // Save dev mode state in persistent store
@@ -369,8 +370,11 @@ async function _initializeApp(state: any) {
     // Menu style is only modified on debug mode.
     const devModeEnabled: boolean = await persistentStore.get('dev_mode') ?? false;
     const debugModeEnabled: boolean = await invoke("is_debug_mode");
-    if (devModeEnabled || debugModeEnabled) {
-        store.commit('toggleDeveloperMode', debugModeEnabled);
+    if (devModeEnabled) {
+        store.commit('toggleDeveloperMode');
+    }
+    if (debugModeEnabled) {
+        store.commit('toggleDebugMode');
     }
 
     // Disable context menu in release build.

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -365,13 +365,16 @@ export const store = createStore<FlightCoreStore>({
  * It invokes all Rust methods that are needed to initialize UI.
  */
 async function _initializeApp(state: any) {
-    console.log("Dev mode:", await persistentStore.get('dev_mode'));
+    // Display dev view if dev mode was previously enabled or if debug mode is active.
+    // Menu style is only modified on debug mode.
+    const devModeEnabled: boolean = await persistentStore.get('dev_mode') ?? false;
+    const debugModeEnabled: boolean = await invoke("is_debug_mode");
+    if (devModeEnabled || debugModeEnabled) {
+        store.commit('toggleDeveloperMode', debugModeEnabled);
+    }
 
-    // Enable dev mode directly if application is in debug mode
-    if (await invoke("is_debug_mode")) {
-        store.commit('toggleDeveloperMode', true);
-    } else {
-        // Disable context menu in release build.
+    // Disable context menu in release build.
+    if (!debugModeEnabled) {
         document.addEventListener('contextmenu', event => event.preventDefault());
     }
 

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -88,7 +88,7 @@ export const store = createStore<FlightCoreStore>({
         checkNorthstarUpdates(state) {
             _get_northstar_version_number(state);
         },
-        toggleDeveloperMode(state, affectMenuStyle = false) {
+        async toggleDeveloperMode(state, affectMenuStyle = false) {
             state.developer_mode = !state.developer_mode;
 
             // Reset tab when closing dev mode.
@@ -100,6 +100,10 @@ export const store = createStore<FlightCoreStore>({
             if (affectMenuStyle && menu_bar_handle !== null) {
                 menu_bar_handle.classList.toggle('developer_build');
             }
+
+            // Save dev mode state in persistent store
+            await persistentStore.set('dev_mode', state.developer_mode);
+            await persistentStore.save();
         },
         initialize(state) {
             _initializeApp(state);
@@ -361,6 +365,8 @@ export const store = createStore<FlightCoreStore>({
  * It invokes all Rust methods that are needed to initialize UI.
  */
 async function _initializeApp(state: any) {
+    console.log("Dev mode:", await persistentStore.get('dev_mode'));
+
     // Enable dev mode directly if application is in debug mode
     if (await invoke("is_debug_mode")) {
         store.commit('toggleDeveloperMode', true);

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -366,8 +366,7 @@ export const store = createStore<FlightCoreStore>({
  * It invokes all Rust methods that are needed to initialize UI.
  */
 async function _initializeApp(state: any) {
-    // Display dev view if dev mode was previously enabled or if debug mode is active.
-    // Menu style is only modified on debug mode.
+    // Display dev view if dev mode was previously enabled.
     const devModeEnabled: boolean = await persistentStore.get('dev_mode') ?? false;
     const debugModeEnabled: boolean = await invoke("is_debug_mode");
     if (devModeEnabled) {


### PR DESCRIPTION
Saves dev mode state in persistent store, so it's automatically enabled on app launch if it was previously enabled.

Closes #214.