### PR TITLE
fix: Fix incorrect is_empty check

### DIFF
--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -480,7 +480,7 @@ pub fn delete_thunderstore_mod(
         }
     }
 
-    if !mod_folders_to_remove.is_empty() {
+    if mod_folders_to_remove.is_empty() {
         return Err(format!(
             "No mods removed as no Northstar mods matching {thunderstore_mod_string} were found to be installed."
         ));


### PR DESCRIPTION
Fixes a regression introduced in #244 that prevented any Thunderstore mods from being uninstalled

Closes #269