### PR TITLE
fix: Repair view add missing i18n

### DIFF
--- a/src-vue/src/i18n/lang/de.json
+++ b/src-vue/src/i18n/lang/de.json
@@ -118,7 +118,7 @@
                 "force_reinstall_ns": "Northstar reinstallieren",
                 "force_delete_temp_dl": "Temporären FlightCore Downloadordner löschen",
                 "delete_persistent_store": "FlightCore Einstellungen zurücksetzen",
-                "reinstall_title": "Northstar zwangsneuinstallieren",
+                "reinstall_title": "Northstar wird neu installiert",
                 "reinstall_text": "Bitte warten",
                 "reinstall_success": "Northstar erfolgreich neu installiert"
             }

--- a/src-vue/src/i18n/lang/de.json
+++ b/src-vue/src/i18n/lang/de.json
@@ -12,7 +12,11 @@
         "no": "Nein",
         "error": "Fehler",
         "cancel": "Abbrechen",
-        "informationShort": "Info"
+        "informationShort": "Info",
+        "downloading": "Herunterladen",
+        "extracting": "Extrahieren",
+        "done": "Fertig",
+        "success": "Erfolg"
     },
 
     "play": {
@@ -110,9 +114,13 @@
                 "title": "FlightCore Reparierfenster",
                 "warning": "Dieses Fenster enthält verschiedene Funktionen um gängige Probleme mit Northstar und FlightCore zu beheben.",
                 "disable_all_but_core": "Alle außer notwendige Mods deaktivieren",
+                "disable_all_but_core_success": "Alle außer notwendige Mods wurden deaktiviert",
                 "force_reinstall_ns": "Northstar reinstallieren",
                 "force_delete_temp_dl": "Temporären FlightCore Downloadordner löschen",
-                "delete_persistent_store": "FlightCore Einstellungen zurücksetzen"
+                "delete_persistent_store": "FlightCore Einstellungen zurücksetzen",
+                "reinstall_title": "Northstar zwangsneuinstallieren",
+                "reinstall_text": "Bitte warten",
+                "reinstall_success": "Northstar erfolgreich neu installiert"
             }
         }
     },

--- a/src-vue/src/i18n/lang/en.json
+++ b/src-vue/src/i18n/lang/en.json
@@ -14,7 +14,9 @@
         "cancel": "Cancel",
         "informationShort": "Info",
         "downloading": "Downloading",
-        "extracting": "Extracting"
+        "extracting": "Extracting",
+        "done": "Done",
+        "success": "Success"
     },
 
     "play": {
@@ -112,9 +114,13 @@
                 "title": "FlightCore repair window",
                 "warning": "This window contains various functionality to repair common issues with Northstar and FlightCore.",
                 "disable_all_but_core": "Disable all but core mods",
+                "disable_all_but_core_success": "Disabled all mods but core",
                 "force_reinstall_ns": "Force reinstall Northstar",
                 "force_delete_temp_dl": "Force delete temp download folder",
-                "delete_persistent_store": "Delete FlightCore persistent store"
+                "delete_persistent_store": "Delete FlightCore persistent store",
+                "reinstall_title": "Force reinstalling Northstar",
+                "reinstall_text": "Please wait",
+                "reinstall_success": "Successfully reinstalled Northstar"
             }
         }
     },

--- a/src-vue/src/i18n/lang/fr.json
+++ b/src-vue/src/i18n/lang/fr.json
@@ -12,7 +12,11 @@
         "no": "Non",
         "error": "Erreur",
         "cancel": "Annuler",
-        "informationShort": "Info"
+        "informationShort": "Info",
+        "downloading": "Téléchargement",
+        "extracting": "Extraction",
+        "done": "Fait",
+        "success": "Succès"
     },
 
     "play": {
@@ -110,9 +114,13 @@
                 "title": "Fenêtre de dépannage FlightCore",
                 "warning": "Cette fenêtre contient plusieurs fonctionnalité de résolution de problèmes courants avec Northstar et FlightCore.",
                 "disable_all_but_core": "Désactiver tous les mods (sauf ceux de Northstar)",
+                "disable_all_but_core_success": "Tous les mods sauf ceux de Northstar ont été désactivés",
                 "force_reinstall_ns": "Forcer la réinstallation de Northstar",
                 "force_delete_temp_dl": "Supprimer le dossier de téléchargement temporaire",
-                "delete_persistent_store": "Supprimer l'espace de stockage local de FlightCore"
+                "delete_persistent_store": "Supprimer l'espace de stockage local de FlightCore",
+                "reinstall_title": "Forcer la réinstallation de Northstar",
+                "reinstall_text": "Veuillez patienter",
+                "reinstall_success": "Northstar réinstallé avec succès"
             }
         }
     },

--- a/src-vue/src/views/RepairView.vue
+++ b/src-vue/src/views/RepairView.vue
@@ -56,7 +56,7 @@ export default defineComponent({
             } as GameInstall;
             await invoke("disable_all_but_core", { gameInstall: game_install })
                 .then((message) => {
-                    showNotification('Success', "Disabled all mods but core");
+                    showNotification(this.$t('generic.success'), this.$t('settings.repair.window.disable_all_but_core_success'));
                 })
                 .catch((error) => {
                     showErrorNotification(error);
@@ -70,8 +70,8 @@ export default defineComponent({
 
             // Send notification telling the user to wait for the process to finish
             const notification = showNotification(
-                'Force reinstalling Northstar',
-                'Please wait',
+                this.$t('settings.repair.window.reinstall_title'),
+                this.$t('settings.repair.window.reinstall_text'),
                 'info',
                 0
             );
@@ -90,7 +90,7 @@ export default defineComponent({
             await install_northstar_result
                 .then((message) => {
                     // Send notification
-                    showNotification('Done', `Successfully reinstalled Northstar`);
+                    showNotification(this.$t('generic.done'), this.$t('settings.repair.window.reinstall_success'));
                     this.$store.commit('checkNorthstarUpdates');
                 })
                 .catch((error) => {
@@ -109,7 +109,7 @@ export default defineComponent({
             } as GameInstall;
             await invoke("clean_up_download_folder_caller", { gameInstall: game_install, force: true }).then((message) => {
                 // Show user notification if task completed.
-                showNotification('Done', 'Done');
+                showNotification(this.$t('generic.done'), this.$t('generic.done'));
             })
                 .catch((error) => {
                     showErrorNotification(error);


### PR DESCRIPTION
Add missing repair view localization entries (I didn't complete German entries though, only English and French).

Closes #260.