### PR TITLE
build: Only upload platform relevant artifacts

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -103,12 +103,14 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
     - name: Upload Linux artifact
+      if: matrix.platform == 'ubuntu-22.04'
       uses: actions/upload-artifact@v3
       with:
         name: linux-artifacts
         path: |
           src-tauri/target/release/bundle/appimage/*
     - name: Upload Windows artifact
+      if: matrix.platform == 'windows-latest'
       uses: actions/upload-artifact@v3
       with:
         name: windows-artifacts


### PR DESCRIPTION
Only upload platform relevant artifacts as opposed to attempt uploading artifacts not relevant to platform

Main reason of doing this is to remove the warning of "missing artifacts" caused by e.g. Windows runner looking for Linux artifacts as well next to Windows artifacts.

The warning message in question shown after CI run:

![image](https://user-images.githubusercontent.com/40122905/232528430-4096b480-00a3-4250-969f-74059a4ff488.png)
