### PR TITLE
build: Additionally upload binaries separately from CI

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -109,6 +109,13 @@ jobs:
         name: linux-artifacts
         path: |
           src-tauri/target/release/bundle/appimage/*
+    - name: Upload Linux AppImage
+      if: matrix.platform == 'ubuntu-22.04'
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux-artifacts
+        path: |
+          src-tauri/target/release/bundle/appimage/*.AppImage
     - name: Upload Windows artifact
       if: matrix.platform == 'windows-latest'
       uses: actions/upload-artifact@v3

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -113,7 +113,7 @@ jobs:
       if: matrix.platform == 'ubuntu-22.04'
       uses: actions/upload-artifact@v3
       with:
-        name: linux-artifacts
+        name: linux-appimage
         path: |
           src-tauri/target/release/bundle/appimage/*.AppImage
     - name: Upload Windows artifact
@@ -128,6 +128,6 @@ jobs:
       if: matrix.platform == 'windows-latest'
       uses: actions/upload-artifact@v3
       with:
-        name: windows-artifacts
+        name: windows-msi
         path: |
           src-tauri/target/release/bundle/msi/*.msi

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -117,3 +117,10 @@ jobs:
         path: |
           src-tauri/target/release/bundle/msi/*
           src-tauri/target/release/app.pdb
+    - name: Additionally upload Windows installer separately
+      if: matrix.platform == 'windows-latest'
+      uses: actions/upload-artifact@v3
+      with:
+        name: windows-artifacts
+        path: |
+          src-tauri/target/release/bundle/msi/*.msi


### PR DESCRIPTION
Additionally uploading binaries separately allows for downloading just those files for testing which results in faster download speeds especially on bad internet.

When testing some PR for some feature, debug information generally isn't needed so being able to download the binary without debug information speeds up the process.

Also allows for linking directly to the zip with just the binary as opposed to the one also including debug information which helps when asking non-developers to test builds.