### PR TITLE
fix: Update regex to match new release notes format

### DIFF
--- a/src-vue/src/views/ChangelogView.vue
+++ b/src-vue/src/views/ChangelogView.vue
@@ -46,7 +46,7 @@ export default defineComponent({
             let content: string = releaseBody.replaceAll(/\@(\S+)/g, `<a target="_blank" href="https://github.com/$1">@$1</a>`);
 
             // PR's links formatting
-            content = content.replaceAll(/\[\#(\S+)\]\(([^)]+)\)/g, `<a target="_blank" href="$2">#$1</a>`);
+            content = content.replaceAll(/\[(\S*)\#(\S+)\]\(([^)]+)\)/g, `<a target="_blank" href="$3">$1#$2</a>`);
 
             return marked.parse(content, {breaks: true});
         },


### PR DESCRIPTION
Updates the regex so it matches both old and new release notes formats used to link to Northstar GitHub PRs.

Here's a testing screenshot with regex101 (it shows that new regex matches both formats):
![Capture d’écran de 2023-04-17 22-16-39](https://user-images.githubusercontent.com/11993538/232600748-328f81ae-58ca-489b-a466-5b360dbb7627.png)

Closes #194.