### PR TITLE
Run `cargo clippy` in CI on each push

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -27,6 +27,18 @@ jobs:
       - name: Format check
         run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
 
+  clippy:
+    name: clippy-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt
+      - name: Run clippy
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml -- --deny warnings
+
   # Ensure committed bindings correct
   autogen-ts-bindings-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Clippy checks for common errors and fails the CI if one is spotted

TODO:
- [ ] Also run for Windows version (some code in FlightCore is OS specific)

Closes #287 