### PR TITLE
feat: Show Thunderstore mod string in alt text

### DIFF
--- a/src-vue/src/views/mods/LocalModsView.vue
+++ b/src-vue/src/views/mods/LocalModsView.vue
@@ -24,7 +24,7 @@
             <span v-if="mod.version != null">(v{{ mod.version }})</span>
             <img
                 v-if="mod.thunderstore_mod_string != null"
-                :title="$t('mods.local.part_of_ts_mod')"
+                :title="$t('mods.local.part_of_ts_mod') + '\n' + mod.thunderstore_mod_string"
                 src="/src/assets/thunderstore-icon.png"
                 class="image"
                 height="16"


### PR DESCRIPTION
This way it's a bit easier to tell which Thunderstore mod a local mod is from.

This is mostly a band-aid solution to the wider spread problem of it being difficult to see which Thunderstore mod a Northstar mod came from.