### PR TITLE
refactor: Put doc comment before macro

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -191,27 +191,27 @@ fn main() {
     };
 }
 
-#[tauri::command]
 /// Wrapper for `find_game_install_location` as tauri doesn't allow passing `Result<>` types to front-end
+#[tauri::command]
 async fn find_game_install_location_caller() -> Result<GameInstall, String> {
     find_game_install_location()
 }
 
-#[tauri::command]
 /// This function's only use is to force a `panic!()`
 // This must NOT be async to ensure crashing whole application.
+#[tauri::command]
 fn force_panic() {
     panic!("Force panicked!");
 }
 
-#[tauri::command]
 /// Returns true if built in debug mode
+#[tauri::command]
 async fn is_debug_mode() -> bool {
     cfg!(debug_assertions)
 }
 
-#[tauri::command]
 /// Returns true if linux compatible
+#[tauri::command]
 async fn linux_checks() -> Result<(), String> {
     // Different behaviour depending on OS
     // MacOS is missing as it is not a target
@@ -227,8 +227,8 @@ async fn linux_checks() -> Result<(), String> {
     }
 }
 
-#[tauri::command]
 /// Returns the current version number as a string
+#[tauri::command]
 async fn get_flightcore_version_number() -> String {
     let version = env!("CARGO_PKG_VERSION");
     if cfg!(debug_assertions) {
@@ -248,10 +248,10 @@ async fn get_northstar_version_number_caller(game_path: String) -> Result<String
     }
 }
 
-#[tauri::command]
 /// Checks if installed Northstar version is up-to-date
 /// false -> Northstar install is up-to-date
 /// true  -> Northstar install is outdated
+#[tauri::command]
 async fn check_is_northstar_outdated(
     game_path: String,
     northstar_package_name: Option<String>,
@@ -295,16 +295,16 @@ async fn check_is_northstar_outdated(
     }
 }
 
-#[tauri::command]
 /// Checks if installed FlightCore version is up-to-date
 /// false -> FlightCore install is up-to-date
 /// true  -> FlightCore install is outdated
+#[tauri::command]
 async fn check_is_flightcore_outdated_caller() -> Result<bool, String> {
     check_is_flightcore_outdated().await
 }
 
-#[tauri::command]
 /// Checks if is valid Titanfall2 install based on certain conditions
+#[tauri::command]
 async fn verify_install_location(game_path: String) -> bool {
     match check_is_valid_game_path(&game_path) {
         Ok(()) => true,
@@ -315,14 +315,14 @@ async fn verify_install_location(game_path: String) -> bool {
     }
 }
 
-#[tauri::command]
 /// Returns identifier of host OS FlightCore is running on
+#[tauri::command]
 async fn get_host_os_caller() -> String {
     get_host_os()
 }
 
-#[tauri::command]
 /// Installs Northstar to the given path
+#[tauri::command]
 async fn install_northstar_caller(
     window: tauri::Window,
     game_path: String,
@@ -338,8 +338,8 @@ async fn install_northstar_caller(
     }
 }
 
-#[tauri::command]
 /// Update Northstar install in the given path
+#[tauri::command]
 async fn update_northstar_caller(
     window: tauri::Window,
     game_path: String,
@@ -357,8 +357,8 @@ async fn update_northstar_caller(
     }
 }
 
-#[tauri::command]
 /// Launches Northstar
+#[tauri::command]
 async fn launch_northstar_caller(
     game_install: GameInstall,
     bypass_checks: Option<bool>,
@@ -366,8 +366,8 @@ async fn launch_northstar_caller(
     launch_northstar(&game_install, bypass_checks)
 }
 
-#[tauri::command]
 /// Launches Northstar
+#[tauri::command]
 async fn launch_northstar_steam_caller(
     game_install: GameInstall,
     bypass_checks: Option<bool>,
@@ -375,8 +375,8 @@ async fn launch_northstar_steam_caller(
     launch_northstar_steam(&game_install, bypass_checks)
 }
 
-#[tauri::command]
 /// Installs the specified mod
+#[tauri::command]
 async fn install_mod_caller(
     game_install: GameInstall,
     thunderstore_mod_string: String,
@@ -393,8 +393,8 @@ async fn install_mod_caller(
     }
 }
 
-#[tauri::command]
 /// Installs the specified mod
+#[tauri::command]
 async fn clean_up_download_folder_caller(
     game_install: GameInstall,
     force: bool,
@@ -435,8 +435,8 @@ async fn get_server_player_count() -> Result<(i32, usize), String> {
     Ok((total_player_count, server_count))
 }
 
-#[tauri::command]
 /// Spawns repair window
+#[tauri::command]
 async fn open_repair_window(handle: tauri::AppHandle) -> Result<(), String> {
     // Spawn new window
     let repair_window = match tauri::WindowBuilder::new(


### PR DESCRIPTION
Doc comments should be placed before the procedural macro decorating the function being documented.