### PR TITLE
refactor: Only pass commit sha for installing launcher CI build

### DIFF
--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -174,9 +174,9 @@ pub async fn get_launcher_download_link(commit_sha: String) -> Result<String, St
             Err(err) => return Err(format!("{}", err)),
         };
 
-        // Cross-reference PR head commit sha against workflow runs
+        // Cross-reference commit sha against workflow runs
         for workflow_run in &runs_response.workflow_runs {
-            // If head commit sha of run and PR match, grab CI output
+            // If head commit sha of CI run matches the one passed to this function, grab CI output
             if workflow_run.head_sha == commit_sha {
                 // Check artifacts
                 let api_url = format!("https://api.github.com/repos/R2Northstar/NorthstarLauncher/actions/runs/{}/artifacts", workflow_run.id);
@@ -187,7 +187,7 @@ pub async fn get_launcher_download_link(commit_sha: String) -> Result<String, St
 
                 // Iterate over artifacts
                 for artifact in artifacts_response.artifacts {
-                    // Make sure run is from PR head commit
+                    // Make sure artifact and CI run commit head sha match
                     if artifact.workflow_run.head_sha == workflow_run.head_sha {
                         dbg!(artifact.id);
 


### PR DESCRIPTION
This refactor allows for easier usage later when installing a launcher build based on commit sha only, e.g. for installing newest build of a branch.

Previously one had to pass an entire pull request struct which was unnecessary as only the commit sha from that struct was actually being used.