### PR TITLE
feat: Add category in changelog for i18n

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -33,8 +33,8 @@ pub const TITANFALL2_ORIGIN_IDS: [&str; 2] = ["Origin.OFR.50.0001452", "Origin.O
 pub const TITANFALL2_STEAM_ID: &str = "1237970";
 
 // Order in which the sections for release notes should be displayed
-pub const SECTION_ORDER: [&str; 9] = [
-    "feat", "fix", "docs", "style", "refactor", "build", "test", "chore", "other",
+pub const SECTION_ORDER: [&str; 10] = [
+    "feat", "fix", "docs", "style", "refactor", "build", "test", "i18n", "chore", "other",
 ];
 
 // GitHub API endpoints for launcher/mods PRs

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -165,6 +165,7 @@ fn generate_flightcore_release_notes(commits: Vec<String>) -> String {
                     "build" => "**Build:**",
                     "test" => "**Tests:**",
                     "chore" => "**Chores:**",
+                    "i18n" => "**Translation:**",
                     _ => "**Other:**",
                 };
 

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -165,7 +165,7 @@ fn generate_flightcore_release_notes(commits: Vec<String>) -> String {
                     "build" => "**Build:**",
                     "test" => "**Tests:**",
                     "chore" => "**Chores:**",
-                    "i18n" => "**Translation:**",
+                    "i18n" => "**Translations:**",
                     _ => "**Other:**",
                 };
 


### PR DESCRIPTION
When auto generating changelog from commit titles, this turns `i18n` (which is what we set weblate PRs to be prefixed with) into `Translations`

So

```
i18n: Add Polish translations via Weblate (#320)
```
becomes
```
**Translations:**
- Add Polish translations via Weblate (#320)
```

For testing, one can simply generate changelog between `v1.14.1` and `v1.15.0` and look at the generated changelog.


Note that I'm well aware _i18n_ stands for _Internationalization_ but _Translations_ sounds more sensible to me in this case ^^