### PR TITLE
refactor: Move `get_enabled_mods` to `main.rs`

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -505,28 +505,3 @@ pub fn convert_release_candidate_number(version_number: String) -> String {
     // Doesn't work for larger numbers, e.g. `v1.9.2-rc11` -> `v1.9.2011` (should be `v1.9.211`)
     version_number.replace("-rc", "0").replace("00", "")
 }
-
-/// Returns a serde json object of the parsed `enabledmods.json` file
-pub fn get_enabled_mods(game_install: &GameInstall) -> Result<serde_json::value::Value, String> {
-    let enabledmods_json_path = format!("{}/R2Northstar/enabledmods.json", game_install.game_path);
-
-    // Check for JSON file
-    if !std::path::Path::new(&enabledmods_json_path).exists() {
-        return Err("enabledmods.json not found".to_string());
-    }
-
-    // Read file
-    let data = match std::fs::read_to_string(enabledmods_json_path) {
-        Ok(data) => data,
-        Err(err) => return Err(err.to_string()),
-    };
-
-    // Parse JSON
-    let res: serde_json::Value = match serde_json::from_str(&data) {
-        Ok(result) => result,
-        Err(err) => return Err(format!("Failed to read JSON due to: {}", err)),
-    };
-
-    // Return parsed data
-    Ok(res)
-}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -471,3 +471,28 @@ async fn close_application<R: Runtime>(app: tauri::AppHandle<R>) -> Result<(), S
     app.exit(0); // Close application
     Ok(())
 }
+
+/// Returns a serde json object of the parsed `enabledmods.json` file
+pub fn get_enabled_mods(game_install: &GameInstall) -> Result<serde_json::value::Value, String> {
+    let enabledmods_json_path = format!("{}/R2Northstar/enabledmods.json", game_install.game_path);
+
+    // Check for JSON file
+    if !std::path::Path::new(&enabledmods_json_path).exists() {
+        return Err("enabledmods.json not found".to_string());
+    }
+
+    // Read file
+    let data = match std::fs::read_to_string(enabledmods_json_path) {
+        Ok(data) => data,
+        Err(err) => return Err(err.to_string()),
+    };
+
+    // Parse JSON
+    let res: serde_json::Value = match serde_json::from_str(&data) {
+        Ok(result) => result,
+        Err(err) => return Err(format!("Failed to read JSON due to: {}", err)),
+    };
+
+    // Return parsed data
+    Ok(res)
+}

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -8,7 +8,7 @@ use app::NorthstarMod;
 use serde::{Deserialize, Serialize};
 use std::{fs, io::Read, path::PathBuf};
 
-use app::get_enabled_mods;
+use crate::get_enabled_mods;
 use app::GameInstall;
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/repair_and_verify/mod.rs
+++ b/src-tauri/src/repair_and_verify/mod.rs
@@ -1,7 +1,8 @@
 use crate::mod_management::{rebuild_enabled_mods_json, set_mod_enabled_status};
 use anyhow::anyhow;
 /// Contains various functions to repair common issues and verifying installation
-use app::{constants::CORE_MODS, get_enabled_mods, GameInstall};
+use app::{constants::CORE_MODS, GameInstall};
+use crate::get_enabled_mods;
 
 /// Verifies Titanfall2 game files
 #[tauri::command]

--- a/src-tauri/src/repair_and_verify/mod.rs
+++ b/src-tauri/src/repair_and_verify/mod.rs
@@ -1,8 +1,8 @@
+use crate::get_enabled_mods;
 use crate::mod_management::{rebuild_enabled_mods_json, set_mod_enabled_status};
 use anyhow::anyhow;
 /// Contains various functions to repair common issues and verifying installation
 use app::{constants::CORE_MODS, GameInstall};
-use crate::get_enabled_mods;
 
 /// Verifies Titanfall2 game files
 #[tauri::command]


### PR DESCRIPTION
Moves  `get_enabled_mods` into `main.rs`. Ultimately it should land in a submodule but moving it there directly while `lib.rs` still exists causes some weird import/export issues that I don't fully understand yet.

Part of #329 
