### PR TITLE
refactor: Move `convert_release_candidate_number` to `main.rs`

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -497,15 +497,6 @@ pub fn check_northstar_running() -> bool {
     x
 }
 
-/// Helps with converting release candidate numbers which are different on Thunderstore
-/// due to restrictions imposed by the platform
-pub fn convert_release_candidate_number(version_number: String) -> String {
-    // This simply converts `-rc` to `0`
-    // Works as intended for RCs < 10, e.g.  `v1.9.2-rc1`  -> `v1.9.201`
-    // Doesn't work for larger numbers, e.g. `v1.9.2-rc11` -> `v1.9.2011` (should be `v1.9.211`)
-    version_number.replace("-rc", "0").replace("00", "")
-}
-
 /// Returns a serde json object of the parsed `enabledmods.json` file
 pub fn get_enabled_mods(game_install: &GameInstall) -> Result<serde_json::value::Value, String> {
     let enabledmods_json_path = format!("{}/R2Northstar/enabledmods.json", game_install.game_path);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -248,6 +248,15 @@ async fn get_northstar_version_number_caller(game_path: String) -> Result<String
     }
 }
 
+/// Helps with converting release candidate numbers which are different on Thunderstore
+/// due to restrictions imposed by the platform
+pub fn convert_release_candidate_number(version_number: String) -> String {
+    // This simply converts `-rc` to `0`
+    // Works as intended for RCs < 10, e.g.  `v1.9.2-rc1`  -> `v1.9.201`
+    // Doesn't work for larger numbers, e.g. `v1.9.2-rc11` -> `v1.9.2011` (should be `v1.9.211`)
+    version_number.replace("-rc", "0").replace("00", "")
+}
+
 /// Checks if installed Northstar version is up-to-date
 /// false -> Northstar install is up-to-date
 /// true  -> Northstar install is outdated


### PR DESCRIPTION
Moves  `convert_release_candidate_number` into `main.rs`. Ultimately it should land in a submodule but moving it there directly while `lib.rs` still exists causes some weird import/export issues that I don't fully understand yet.

Part of #329 
