### PR TITLE
refactor: Move `check_is_valid_game_path` to `main.rs`

### DIFF
--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -1,7 +1,7 @@
 use crate::github::release_notes::fetch_github_releases_api;
 
+use crate::check_is_valid_game_path;
 use anyhow::anyhow;
-use app::check_is_valid_game_path;
 use app::constants::{APP_USER_AGENT, PULLS_API_ENDPOINT_LAUNCHER, PULLS_API_ENDPOINT_MODS};
 use serde::{Deserialize, Serialize};
 use std::fs::File;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -145,19 +145,6 @@ pub fn find_game_install_location() -> Result<GameInstall, String> {
     Err("Could not auto-detect game install location! Please enter it manually.".to_string())
 }
 
-/// Checks whether the provided path is a valid Titanfall2 gamepath by checking against a certain set of criteria
-pub fn check_is_valid_game_path(game_install_path: &str) -> Result<(), String> {
-    let path_to_titanfall2_exe = format!("{game_install_path}/Titanfall2.exe");
-    let is_correct_game_path = std::path::Path::new(&path_to_titanfall2_exe).exists();
-    log::info!("Titanfall2.exe exists in path? {}", is_correct_game_path);
-
-    // Exit early if wrong game path
-    if !is_correct_game_path {
-        return Err(format!("Incorrect game path \"{game_install_path}\"")); // Return error cause wrong game path
-    }
-    Ok(())
-}
-
 /// Copied from `papa` source code and modified
 ///Extract N* zip file to target game path
 // fn extract(ctx: &Ctx, zip_file: File, target: &Path) -> Result<()> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -303,6 +303,19 @@ async fn check_is_flightcore_outdated_caller() -> Result<bool, String> {
     check_is_flightcore_outdated().await
 }
 
+/// Checks whether the provided path is a valid Titanfall2 gamepath by checking against a certain set of criteria
+pub fn check_is_valid_game_path(game_install_path: &str) -> Result<(), String> {
+    let path_to_titanfall2_exe = format!("{game_install_path}/Titanfall2.exe");
+    let is_correct_game_path = std::path::Path::new(&path_to_titanfall2_exe).exists();
+    log::info!("Titanfall2.exe exists in path? {}", is_correct_game_path);
+
+    // Exit early if wrong game path
+    if !is_correct_game_path {
+        return Err(format!("Incorrect game path \"{game_install_path}\"")); // Return error cause wrong game path
+    }
+    Ok(())
+}
+
 /// Checks if is valid Titanfall2 install based on certain conditions
 #[tauri::command]
 async fn verify_install_location(game_path: String) -> bool {


### PR DESCRIPTION
Moves  `check_is_valid_game_path` into `main.rs`. Ultimately it should land in a submodule but moving it there directly while `lib.rs` still exists causes some weird import/export issues that I don't fully understand yet.

Part of #329