### PR TITLE
fix: Pass correct argument to `get_launcher_download_link`

### DIFF
--- a/src-vue/src/plugins/modules/pull_requests.ts
+++ b/src-vue/src/plugins/modules/pull_requests.ts
@@ -37,7 +37,7 @@ export const pullRequestModule = {
                 });
         },
         async downloadLauncherPR(state: PullRequestStoreState, pull_request: PullsApiResponseElement) {
-            await invoke<string>("get_launcher_download_link", { pullRequest: pull_request })
+            await invoke<string>("get_launcher_download_link", { commitSha: pull_request.head.sha })
                 .then((url) => {
                     // Open URL in default HTTPS handler (i.e. default browser)
                     shell.open(url);


### PR DESCRIPTION
Function signature changed in #313 but frontend was never updated.

To test, simply try using the _Download_ button on a Northstar launcher pull request without/with this PR.

Closes #343 