### PR TITLE
refactor: Move some functions to utility module

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -31,6 +31,8 @@ use northstar::get_northstar_version_number;
 mod thunderstore;
 use thunderstore::query_thunderstore_packages_api;
 
+mod util;
+
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use tauri::{Manager, Runtime};
@@ -119,7 +121,7 @@ fn main() {
         })
         .manage(Counter(Default::default()))
         .invoke_handler(tauri::generate_handler![
-            force_panic,
+            util::force_panic,
             find_game_install_location_caller,
             get_flightcore_version_number,
             get_northstar_version_number_caller,
@@ -199,13 +201,6 @@ fn main() {
 #[tauri::command]
 async fn find_game_install_location_caller() -> Result<GameInstall, String> {
     find_game_install_location()
-}
-
-/// This function's only use is to force a `panic!()`
-// This must NOT be async to ensure crashing whole application.
-#[tauri::command]
-fn force_panic() {
-    panic!("Force panicked!");
 }
 
 /// Returns true if built in debug mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -137,7 +137,7 @@ fn main() {
             repair_and_verify::verify_game_files,
             mod_management::set_mod_enabled_status,
             repair_and_verify::disable_all_but_core,
-            is_debug_mode,
+            util::is_debug_mode,
             github::release_notes::get_northstar_release_notes,
             linux_checks,
             mod_management::get_installed_mods_and_properties,
@@ -201,12 +201,6 @@ fn main() {
 #[tauri::command]
 async fn find_game_install_location_caller() -> Result<GameInstall, String> {
     find_game_install_location()
-}
-
-/// Returns true if built in debug mode
-#[tauri::command]
-async fn is_debug_mode() -> bool {
-    cfg!(debug_assertions)
 }
 
 /// Returns true if linux compatible

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,0 +1,8 @@
+//! This module contains various utility/helper functions that do not fit into any other module
+
+/// This function's only use is to force a `panic!()`
+// This must NOT be async to ensure crashing whole application.
+#[tauri::command]
+pub fn force_panic() {
+    panic!("Force panicked!");
+}

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -6,3 +6,9 @@
 pub fn force_panic() {
     panic!("Force panicked!");
 }
+
+/// Returns true if built in debug mode
+#[tauri::command]
+pub async fn is_debug_mode() -> bool {
+    cfg!(debug_assertions)
+}


### PR DESCRIPTION
Moves `force_panic` and `is_debug_mode` to `utility.rs` to cleanup `main.rs`.

For testing:
- `force_panic`: simply do a force panic via DevView. FlightCore should crash as expected
- `is_debug_mode`: Debug build should show stripes on top bar while non-debug should not show them