### PR TITLE
refactor: Move server browser fetch to util module

### DIFF
--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,5 +1,15 @@
 //! This module contains various utility/helper functions that do not fit into any other module
 
+use serde::{Deserialize, Serialize};
+
+use crate::constants::{APP_USER_AGENT, MASTER_SERVER_URL, SERVER_BROWSER_ENDPOINT};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NorthstarServer {
+    #[serde(rename = "playerCount")]
+    pub player_count: i32,
+}
+
 /// This function's only use is to force a `panic!()`
 // This must NOT be async to ensure crashing whole application.
 #[tauri::command]
@@ -11,4 +21,42 @@ pub fn force_panic() {
 #[tauri::command]
 pub async fn is_debug_mode() -> bool {
     cfg!(debug_assertions)
+}
+
+/// Fetches `/client/servers` endpoint from master server
+async fn fetch_server_list() -> Result<String, anyhow::Error> {
+    let url = format!("{MASTER_SERVER_URL}{SERVER_BROWSER_ENDPOINT}");
+    let client = reqwest::Client::new();
+    let res = client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, APP_USER_AGENT)
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    Ok(res)
+}
+
+/// Gets server and playercount from master server API
+#[tauri::command]
+pub async fn get_server_player_count() -> Result<(i32, usize), String> {
+    let res = match fetch_server_list().await {
+        Ok(res) => res,
+        Err(err) => return Err(err.to_string()),
+    };
+
+    let ns_servers: Vec<NorthstarServer> =
+        serde_json::from_str(&res).expect("JSON was not well-formatted");
+
+    // Get server count
+    let server_count = ns_servers.len();
+
+    // Sum up player count
+    let total_player_count: i32 = ns_servers.iter().map(|server| server.player_count).sum();
+
+    log::info!("total_player_count: {}", total_player_count);
+    log::info!("server_count:       {}", server_count);
+
+    Ok((total_player_count, server_count))
 }


### PR DESCRIPTION
To clean up `main.rs`

For testing simply launch FlightCore and see if it can fetch playercount.

Part of #351 