### PR TITLE
refactor: Change error messages and function names to EA App

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -94,7 +94,7 @@ fn main() {
                     sleep(Duration::from_millis(2000)).await;
                     app_handle
                         .emit_all(
-                            "origin-running-ping",
+                            "ea-app-running-ping",
                             util::check_ea_app_or_origin_running(),
                         )
                         .unwrap();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -93,7 +93,7 @@ fn main() {
                 loop {
                     sleep(Duration::from_millis(2000)).await;
                     app_handle
-                        .emit_all("origin-running-ping", util::check_origin_running())
+                        .emit_all("origin-running-ping", util::check_ea_app_or_origin_running())
                         .unwrap();
                 }
             });

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -93,7 +93,10 @@ fn main() {
                 loop {
                     sleep(Duration::from_millis(2000)).await;
                     app_handle
-                        .emit_all("origin-running-ping", util::check_ea_app_or_origin_running())
+                        .emit_all(
+                            "origin-running-ping",
+                            util::check_ea_app_or_origin_running(),
+                        )
                         .unwrap();
                 }
             });

--- a/src-tauri/src/northstar/mod.rs
+++ b/src-tauri/src/northstar/mod.rs
@@ -86,7 +86,7 @@ pub fn launch_northstar(
             return Err(anyhow!("Not all checks were met").to_string());
         }
 
-        // Require Origin to be running to launch Northstar
+        // Require EA App or Origin to be running to launch Northstar
         let ea_app_is_running = check_ea_app_or_origin_running();
         if !ea_app_is_running {
             return Err(

--- a/src-tauri/src/northstar/mod.rs
+++ b/src-tauri/src/northstar/mod.rs
@@ -87,8 +87,8 @@ pub fn launch_northstar(
         }
 
         // Require Origin to be running to launch Northstar
-        let origin_is_running = check_origin_running();
-        if !origin_is_running {
+        let ea_app_is_running = check_origin_running();
+        if !ea_app_is_running {
             return Err(
                 anyhow!("EA App not running, start EA App before launching Northstar").to_string(),
             );

--- a/src-tauri/src/northstar/mod.rs
+++ b/src-tauri/src/northstar/mod.rs
@@ -90,7 +90,7 @@ pub fn launch_northstar(
         let origin_is_running = check_origin_running();
         if !origin_is_running {
             return Err(
-                anyhow!("Origin not running, start Origin before launching Northstar").to_string(),
+                anyhow!("EA App not running, start EA App before launching Northstar").to_string(),
             );
         }
     }

--- a/src-tauri/src/northstar/mod.rs
+++ b/src-tauri/src/northstar/mod.rs
@@ -2,7 +2,7 @@
 //! - getting version number
 pub mod install;
 
-use crate::util::check_origin_running;
+use crate::util::check_ea_app_or_origin_running;
 use crate::{constants::CORE_MODS, get_host_os, GameInstall, InstallType};
 use anyhow::anyhow;
 
@@ -87,7 +87,7 @@ pub fn launch_northstar(
         }
 
         // Require Origin to be running to launch Northstar
-        let ea_app_is_running = check_origin_running();
+        let ea_app_is_running = check_ea_app_or_origin_running();
         if !ea_app_is_running {
             return Err(
                 anyhow!("EA App not running, start EA App before launching Northstar").to_string(),

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -105,7 +105,7 @@ pub fn extract(zip_file: std::fs::File, target: &std::path::Path) -> Result<()> 
     Ok(())
 }
 
-pub fn check_origin_running() -> bool {
+pub fn check_ea_app_or_origin_running() -> bool {
     let s = sysinfo::System::new_all();
     let x = s.processes_by_name("Origin.exe").next().is_some()
         || s.processes_by_name("EADesktop.exe").next().is_some();

--- a/src-vue/src/i18n/lang/de.json
+++ b/src-vue/src/i18n/lang/de.json
@@ -33,7 +33,7 @@
         "servers": "Server",
         "unable_to_load_playercount": "Spielerzahl konnte nicht geladen werden",
         "northstar_running": "Northstar läuft:",
-        "origin_running": "Origin läuft:"
+        "ea_app_running": "EA App läuft:"
     },
     "mods": {
         "local": {

--- a/src-vue/src/i18n/lang/en.json
+++ b/src-vue/src/i18n/lang/en.json
@@ -36,7 +36,7 @@
         "servers": "servers",
         "unable_to_load_playercount": "Unable to load playercount",
         "northstar_running": "Northstar is running:",
-        "origin_running": "Origin is running:"
+        "ea_app_running": "EA App is running:"
     },
 
     "mods": {

--- a/src-vue/src/i18n/lang/fr.json
+++ b/src-vue/src/i18n/lang/fr.json
@@ -33,7 +33,7 @@
         "servers": "serveurs",
         "unable_to_load_playercount": "Impossible de charger les statistiques",
         "northstar_running": "Northstar est en cours d'exécution :",
-        "origin_running": "Origin est en cours d'exécution :"
+        "ea_app_running": "EA App est en cours d'exécution :"
     },
     "mods": {
         "local": {

--- a/src-vue/src/i18n/lang/pl.json
+++ b/src-vue/src/i18n/lang/pl.json
@@ -32,7 +32,7 @@
         "players": "gracze",
         "servers": "serwery",
         "northstar_running": "Northstar jest uruchomiony:",
-        "origin_running": "Origin jest uruchomiony:",
+        "ea_app_running": "EA App jest uruchomiony:",
         "unable_to_load_playercount": "Nie można załadować liczby graczy"
     },
     "mods": {

--- a/src-vue/src/i18n/lang/ru.json
+++ b/src-vue/src/i18n/lang/ru.json
@@ -32,7 +32,7 @@
         "servers": "серверов",
         "unable_to_load_playercount": "Не можем загрузить количество игроков",
         "northstar_running": "Нордстар запущен:",
-        "origin_running": "Origin запущен:",
+        "ea_app_running": "EA App запущен:",
         "see_patch_notes": "просмотреть список изменений"
     },
     "mods": {

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -463,7 +463,7 @@ async function _checkForFlightCoreUpdates(state: FlightCoreStore) {
  * Those events include Origin and Northstar running state.
  */
 function _initializeListeners(state: any) {
-    listen("origin-running-ping", function (evt: TauriEvent<any>) {
+    listen("ea-app-running-ping", function (evt: TauriEvent<any>) {
         state.origin_is_running = evt.payload as boolean;
     });
 

--- a/src-vue/src/views/PlayView.vue
+++ b/src-vue/src/views/PlayView.vue
@@ -57,7 +57,7 @@ export default defineComponent({
                     <div class="fc_version__line fc_version__line__boolean"> {{ northstarIsRunning }}</div>
                 </div>
                 <div>
-                    <div class="fc_version__line">{{ $t('play.origin_running') }}</div>
+                    <div class="fc_version__line">{{ $t('play.ea_app_running') }}</div>
                     <div class="fc_version__line fc_version__line__boolean">{{ $store.state.origin_is_running }}</div>
                 </div>
             </div>


### PR DESCRIPTION
With EA App replacing Origin we should update our error messages and relevant function names accordingly.

Closes #361 

TODO:
- [x] Backend
  - [x] Other stuff
- [x] Frontend
  - [x] Translations
  - [x] Function names
  - [x] Object field names