### PR TITLE
fix: Handle case when failing to connect to TS while trying to install NS

### DIFF
--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -109,7 +109,13 @@ pub async fn install_northstar(
     northstar_package_name: String,
     version_number: Option<String>,
 ) -> Result<String, String> {
-    let index = thermite::api::get_package_index().unwrap().to_vec();
+    let index = match thermite::api::get_package_index() {
+        Ok(res) => res.to_vec(),
+        Err(err) => {
+            log::warn!("Failed fetching package index due to: {err}");
+            return Err("Failed to connect to Thunderstore.".to_string());
+        }
+    };
     let nmod = index
         .iter()
         .find(|f| f.name.to_lowercase() == northstar_package_name.to_lowercase())


### PR DESCRIPTION
Handle case  instead of panicking when failing to connect to Thunderstore while trying to install Northstar.

Resolves https://northstar-kv.sentry.io/issues/4188330874/
Part of #33 