### PR TITLE
Add antivirus mention to `Failed to connect to Thunderstore.` error

### DIFF
--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -117,7 +117,7 @@ pub async fn install_northstar(
         Ok(res) => res.to_vec(),
         Err(err) => {
             log::warn!("Failed fetching package index due to: {err}");
-            return Err("Failed to connect to Thunderstore.".to_string());
+            return Err("Failed to connect to Thunderstore.\n If you have an antivirus program, try letting FlightCore through it.".to_string());
         }
     };
     let nmod = index


### PR DESCRIPTION
This (probably) works 

Can double check later at home today if it's functionality is questionable, but as far as my code knowledge goes `\n` should also work here