### PR TITLE
i18n: Enable Italian translations

### DIFF
--- a/src-vue/src/components/LanguageSelector.vue
+++ b/src-vue/src/components/LanguageSelector.vue
@@ -42,6 +42,10 @@ export default defineComponent({
                 value: 'ru',
                 label: 'русский'
             },
+            {
+                value: 'it',
+                label: 'Italiano'
+            },
         ]
     }),
     mounted: async function () {

--- a/src-vue/src/main.ts
+++ b/src-vue/src/main.ts
@@ -16,6 +16,7 @@ import fr from "./i18n/lang/fr.json";
 import de from "./i18n/lang/de.json";
 import pl from "./i18n/lang/pl.json";
 import ru from "./i18n/lang/ru.json";
+import it from "./i18n/lang/it.json";
 
 
 const app = createApp(App);
@@ -25,7 +26,7 @@ export const i18n = createI18n({
     locale: 'en',
     fallbackLocale: 'en',
     messages: {
-        en, fr, de, pl, ru
+        en, fr, de, pl, ru, it
     }
 });
 app.use(i18n);


### PR DESCRIPTION
Adds _Italian_ into the language dropdown menu in settings.

![image](https://github.com/R2NorthstarTools/FlightCore/assets/40122905/eea0a4f4-1402-4bf9-b8ad-4508cd35cee2)

Requires #366 