### PR TITLE
feat: Log folder names when indexing mods

### DIFF
--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -216,7 +216,9 @@ fn parse_installed_mods(game_install: &GameInstall) -> Result<Vec<NorthstarMod>,
 
     // Get list of folders in `mods` directory
     for path in paths {
+        log::info!("{path:?}");
         let my_path = path.unwrap().path();
+        log::info!("{my_path:?}");
 
         let md = std::fs::metadata(my_path.clone()).unwrap();
         if md.is_dir() {


### PR DESCRIPTION
Logs the folders accessed when trying to discover mods.

Reason being that we have some weird crash based on directory that I haven't fully figured out so this should help in discovering it.