### PR TITLE
fix: Remove some unwraps for fetching GitHub API

### DIFF
--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -74,7 +74,7 @@ pub async fn get_pull_requests(url: String) -> Result<Vec<PullsApiResponseElemen
 
         let json_response = match fetch_github_releases_api(&paginated_url).await {
             Ok(result) => result,
-            Err(err) => return Err(err),
+            Err(err) => return Err(format!("Failed fetching GitHub API {err}")),
         };
 
         let pulls_response: Vec<PullsApiResponseElement> =

--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -19,7 +19,7 @@ pub struct FlightCoreVersion {
 }
 
 // Fetches repo release API and returns response as string
-pub async fn fetch_github_releases_api(url: &str) -> Result<String, String> {
+pub async fn fetch_github_releases_api(url: &str) -> Result<String, anyhow::Error> {
     log::info!("Fetching releases notes from GitHub API");
 
     let client = reqwest::Client::new();
@@ -27,11 +27,9 @@ pub async fn fetch_github_releases_api(url: &str) -> Result<String, String> {
         .get(url)
         .header(reqwest::header::USER_AGENT, APP_USER_AGENT)
         .send()
-        .await
-        .unwrap()
+        .await?
         .text()
-        .await
-        .unwrap();
+        .await?;
 
     Ok(res)
 }
@@ -42,7 +40,10 @@ pub async fn get_newest_flightcore_version() -> Result<FlightCoreVersion, String
     // Get newest version number from GitHub API
     log::info!("Checking GitHub API");
     let url = "https://api.github.com/repos/R2NorthstarTools/FlightCore/releases/latest";
-    let res = fetch_github_releases_api(url).await?;
+    let res = match fetch_github_releases_api(url).await {
+        Ok(res) => res,
+        Err(err) => return Err(format!("Failed getting newest FlightCore version: {err}")),
+    };
 
     let flightcore_version: FlightCoreVersion =
         serde_json::from_str(&res).expect("JSON was not well-formatted");
@@ -95,7 +96,10 @@ pub async fn check_is_flightcore_outdated() -> Result<bool, String> {
 #[tauri::command]
 pub async fn get_northstar_release_notes() -> Result<Vec<ReleaseInfo>, String> {
     let url = "https://api.github.com/repos/R2Northstar/Northstar/releases";
-    let res = fetch_github_releases_api(url).await?;
+    let res = match fetch_github_releases_api(url).await {
+        Ok(res) => res,
+        Err(err) => return Err(format!("Failed getting Northstar release notes: {err}")),
+    };
 
     let release_info_vector: Vec<ReleaseInfo> = match serde_json::from_str(&res) {
         Ok(res) => res,


### PR DESCRIPTION
Remove some unwraps for fetching GitHub API to prevent thread from panicking on no internet

Addresses: https://northstar-kv.sentry.io/share/issue/3ebc5a2c95234439863ad80a5001f203/ (finally found out how to publicly share crash reports)

Part of #33