### PR TITLE
fix: Remove unwrap from Northstar update check

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -263,7 +263,10 @@ async fn check_is_northstar_outdated(
         None => "Northstar".to_string(),
     };
 
-    let index = thermite::api::get_package_index().unwrap().to_vec();
+    let index = match thermite::api::get_package_index() {
+        Ok(res) => res.to_vec(),
+        Err(err) => return Err(format!("Couldn't check if Northstar up-to-date: {err}")),
+    };
     let nmod = index
         .iter()
         .find(|f| f.name.to_lowercase() == northstar_package_name.to_lowercase())


### PR DESCRIPTION
Removes an `unwrap` that would cause  a thread crash on update checking without internet.

Addresses https://northstar-kv.sentry.io/share/issue/086424ab97b541acad0a7d0d5c9b65b2/
Part of #33