### PR TITLE
feat: Show outdated Thunderstore mods first

### DIFF
--- a/src-vue/src/components/ModsMenu.vue
+++ b/src-vue/src/components/ModsMenu.vue
@@ -9,7 +9,15 @@
                 <el-icon><Folder /></el-icon>
                 <span>{{ $t('mods.menu.local') }}</span>
             </el-menu-item>
-            <el-menu-item index="2" @click="$emit('showLocalMods', false)">
+
+            <!-- Display a badge if there are some outdated Thunderstore mods -->
+            <el-menu-item v-if="outdatedThunderstoreModsCount !== 0" index="2" @click="$emit('showLocalMods', false)">
+                <el-badge :value="outdatedThunderstoreModsCount" class="item" type="warning">
+                    <el-icon><Connection /></el-icon>
+                    <span>{{ $t('mods.menu.online') }}</span>
+                </el-badge>
+            </el-menu-item>
+            <el-menu-item v-else index="2" @click="$emit('showLocalMods', false)">
                 <el-icon><Connection /></el-icon>
                 <span>{{ $t('mods.menu.online') }}</span>
             </el-menu-item>
@@ -50,6 +58,8 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import { SortOptions } from '../utils/SortOptions.d';
+import {isThunderstoreModOutdated} from "../utils/thunderstore/version";
+import {ThunderstoreMod} from "../../../src-tauri/bindings/ThunderstoreMod";
 
 export default defineComponent({
     name: 'ModsMenu',
@@ -63,6 +73,11 @@ export default defineComponent({
         this.$store.state.search.sortValue = this.sortValues[3].value;
     },
     computed: {
+        outdatedThunderstoreModsCount(): number {
+            return this.$store.state.thunderstoreMods
+                .filter((mod: ThunderstoreMod) => isThunderstoreModOutdated(mod))
+                .length;
+        },
         sortValues(): { label: string, value: string }[] {
             return Object.keys(SortOptions).map((key: string) => ({
                 value: key,
@@ -114,5 +129,13 @@ export default defineComponent({
 .el-select {
     width: 100%;
     margin-top: 5px;
+}
+
+/* Outdated thunderstore mods count */
+.el-badge {
+    width: 100%;
+}
+.el-badge:deep(.el-badge__content) {
+    top: 28px !important;
 }
 </style>

--- a/src-vue/src/components/ModsMenu.vue
+++ b/src-vue/src/components/ModsMenu.vue
@@ -58,8 +58,8 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import { SortOptions } from '../utils/SortOptions.d';
-import {isThunderstoreModOutdated} from "../utils/thunderstore/version";
-import {ThunderstoreMod} from "../../../src-tauri/bindings/ThunderstoreMod";
+import { isThunderstoreModOutdated } from "../utils/thunderstore/version";
+import { ThunderstoreMod } from "../../../src-tauri/bindings/ThunderstoreMod";
 
 export default defineComponent({
     name: 'ModsMenu',

--- a/src-vue/src/utils/thunderstore/version.ts
+++ b/src-vue/src/utils/thunderstore/version.ts
@@ -1,6 +1,6 @@
-import { ThunderstoreMod } from "../../../../src-tauri/bindings/ThunderstoreMod";
-import { NorthstarMod } from "../../../../src-tauri/bindings/NorthstarMod";
-import { store } from "../../plugins/store";
+import {ThunderstoreMod} from "../../../../src-tauri/bindings/ThunderstoreMod";
+import {NorthstarMod} from "../../../../src-tauri/bindings/NorthstarMod";
+import {store} from "../../plugins/store";
 
 /**
  * Strips off a Thunderstore dependency string from its version
@@ -23,7 +23,8 @@ function isThunderstoreModOutdated(mod: ThunderstoreMod): boolean {
         // There shouldn't be several mods with same dependency string, but we never know...
         const matchingMod = matchingMods[0];
         // A mod is outdated if its dependency strings differs from Thunderstore dependency string
-        // (no need for semver check here)
+        // (no need for semver check here).
+        // This assumes mod versions list is sorted from newest to oldest version.
         return matchingMod.thunderstore_mod_string !== mod.versions[0].full_name;
     }
     return false;

--- a/src-vue/src/utils/thunderstore/version.ts
+++ b/src-vue/src/utils/thunderstore/version.ts
@@ -1,6 +1,6 @@
-import {ThunderstoreMod} from "../../../../src-tauri/bindings/ThunderstoreMod";
-import {NorthstarMod} from "../../../../src-tauri/bindings/NorthstarMod";
-import {store} from "../../plugins/store";
+import { ThunderstoreMod } from "../../../../src-tauri/bindings/ThunderstoreMod";
+import { NorthstarMod } from "../../../../src-tauri/bindings/NorthstarMod";
+import { store } from "../../plugins/store";
 
 /**
  * Strips off a Thunderstore dependency string from its version

--- a/src-vue/src/utils/thunderstore/version.ts
+++ b/src-vue/src/utils/thunderstore/version.ts
@@ -1,0 +1,32 @@
+import {ThunderstoreMod} from "../../../../src-tauri/bindings/ThunderstoreMod";
+import {NorthstarMod} from "../../../../src-tauri/bindings/NorthstarMod";
+import {store} from "../../plugins/store";
+
+/**
+ * Strips off a Thunderstore dependency string from its version
+ * (e.g. "taskinoz-WallrunningTitans-1.0.0" to
+ * "taskinoz-WallrunningTitans").
+ **/
+function getThunderstoreDependencyStringPrefix(dependency: string): string {
+    const dependencyStringMembers = dependency.split('-');
+    return `${dependencyStringMembers[0]}-${dependencyStringMembers[1]}`;
+}
+
+function isThunderstoreModOutdated(mod: ThunderstoreMod): boolean {
+    // Ensure mod is up-to-date.
+    const tsModPrefix = getThunderstoreDependencyStringPrefix(mod.versions[0].full_name);
+    const matchingMods: NorthstarMod[] = store.state.installed_mods.filter((mod: NorthstarMod) => {
+        if (!mod.thunderstore_mod_string) return false;
+        return getThunderstoreDependencyStringPrefix(mod.thunderstore_mod_string!) === tsModPrefix;
+    });
+    if (matchingMods.length !== 0) {
+        // There shouldn't be several mods with same dependency string, but we never know...
+        const matchingMod = matchingMods[0];
+        // A mod is outdated if its dependency strings differs from Thunderstore dependency string
+        // (no need for semver check here)
+        return matchingMod.thunderstore_mod_string !== mod.versions[0].full_name;
+    }
+    return false;
+}
+
+export { isThunderstoreModOutdated };

--- a/src-vue/src/views/ModsView.vue
+++ b/src-vue/src/views/ModsView.vue
@@ -37,6 +37,10 @@ export default defineComponent({
         return {
             show_local_mods: true,
         }
+    },
+    mounted() {
+        // Fetch Thunderstore mods to eventually display outdated mods count
+        this.$store.commit('fetchThunderstoreMods');
     }
 });
 </script>

--- a/src-vue/src/views/mods/ThunderstoreModsView.vue
+++ b/src-vue/src/views/mods/ThunderstoreModsView.vue
@@ -52,6 +52,7 @@ import { ElScrollbar, ScrollbarInstance } from "element-plus";
 import { SortOptions } from "../../utils/SortOptions.d";
 import { ThunderstoreModVersion } from "../../../../src-tauri/bindings/ThunderstoreModVersion";
 import { fuzzy_filter } from "../../utils/filter";
+import {isThunderstoreModOutdated} from "../../utils/thunderstore/version";
 
 export default defineComponent({
     name: "ThunderstoreModsView",
@@ -137,7 +138,17 @@ export default defineComponent({
                     throw new Error('Unknown mod sorting.');
             }
 
-            return mods.sort(compare);
+            // Display outdated mods first
+            const sortedMods = mods.sort(compare);
+            return sortedMods.sort((a, b) => {
+                if (isThunderstoreModOutdated(a)) {
+                    return -1;
+                } else if (isThunderstoreModOutdated(b)) {
+                    return 1;
+                } else {
+                    return compare(a, b);
+                }
+            })
         },
         modsPerPage(): number {
             return parseInt(this.$store.state.mods_per_page);

--- a/src-vue/src/views/mods/ThunderstoreModsView.vue
+++ b/src-vue/src/views/mods/ThunderstoreModsView.vue
@@ -139,7 +139,8 @@ export default defineComponent({
                     throw new Error('Unknown mod sorting.');
             }
 
-            // Display outdated mods first
+            // Always display outdated mods first
+            // (regardless of actual sort order)
             const sortedMods = mods.sort(compare);
             return sortedMods.sort((a, b) => {
                 if (isThunderstoreModOutdated(a)) {

--- a/src-vue/src/views/mods/ThunderstoreModsView.vue
+++ b/src-vue/src/views/mods/ThunderstoreModsView.vue
@@ -52,7 +52,8 @@ import { ElScrollbar, ScrollbarInstance } from "element-plus";
 import { SortOptions } from "../../utils/SortOptions.d";
 import { ThunderstoreModVersion } from "../../../../src-tauri/bindings/ThunderstoreModVersion";
 import { fuzzy_filter } from "../../utils/filter";
-import {isThunderstoreModOutdated} from "../../utils/thunderstore/version";
+import { isThunderstoreModOutdated } from "../../utils/thunderstore/version";
+
 
 export default defineComponent({
     name: "ThunderstoreModsView",


### PR DESCRIPTION
* A badge displays count of outdated mods
* Outdated mods are always displayed first

![image](https://github.com/R2NorthstarTools/FlightCore/assets/11993538/e9809eed-4c9b-46bf-96ac-f12252b3971c)

Closes #293.