### PR TITLE
feat: Select most recent release tags after fetch

### DIFF
--- a/src-vue/src/views/DeveloperView.vue
+++ b/src-vue/src/views/DeveloperView.vue
@@ -232,8 +232,8 @@ export default defineComponent({
                 .then((message) => {
                     this.ns_release_tags = message;
                     showNotification("Done", "Fetched tags");
-                    this.first_tag = this.ns_release_tags[0];
-                    this.second_tag = this.ns_release_tags[1];
+                    this.first_tag = this.ns_release_tags[1];
+                    this.second_tag = this.ns_release_tags[0];
                 })
                 .catch((error) => {
                     showErrorNotification(error);

--- a/src-vue/src/views/DeveloperView.vue
+++ b/src-vue/src/views/DeveloperView.vue
@@ -232,6 +232,8 @@ export default defineComponent({
                 .then((message) => {
                     this.ns_release_tags = message;
                     showNotification("Done", "Fetched tags");
+                    this.first_tag = this.ns_release_tags[0];
+                    this.second_tag = this.ns_release_tags[1];
                 })
                 .catch((error) => {
                     showErrorNotification(error);


### PR DESCRIPTION
Basically just autosets the tags to the last two recent so that in most cases I can just directly click on `Compare tags` without having to manually select the first ^^

![image](https://github.com/R2NorthstarTools/FlightCore/assets/40122905/05e1eac4-a16d-4f21-94b1-22a1216638b3)
