### PR TITLE
fix: Display install messages even outside mod view

### DIFF
--- a/src-vue/src/components/ThunderstoreModCard.vue
+++ b/src-vue/src/components/ThunderstoreModCard.vue
@@ -251,8 +251,11 @@ export default defineComponent({
                 this.isBeingInstalled = true;
             }
 
-            await invoke<string>("install_mod_caller", { gameInstall: game_install, thunderstoreModString: this.latestVersion.full_name }).then((message) => {
-                showNotification(this.$t('mods.card.install_success', { modName: mod.name }), message);
+            // Capture translation method in a context, so it can be used outside Vue component context.
+            // (see https://github.com/R2NorthstarTools/FlightCore/issues/384)
+            (async (translate: Function) => {
+                await invoke<string>("install_mod_caller", { gameInstall: game_install, thunderstoreModString: this.latestVersion.full_name }).then((message) => {
+                showNotification(translate('mods.card.install_success', { modName: mod.name }), message);
             })
                 .catch((error) => {
                     showErrorNotification(error);
@@ -262,6 +265,9 @@ export default defineComponent({
                     this.isBeingUpdated = false;
                     this.$store.commit('loadInstalledMods');
                 });
+            // @ts-ignore
+            })(this.$i18n.t);
+
         },
     }
 });


### PR DESCRIPTION
Mod installation notification translation would fail when invoked outside of the triggering Vue component; this addresses the issue by capturing the translation method in a context, so it's available when notification is fired up.

---

###### Without this PR

![image](https://github.com/R2NorthstarTools/FlightCore/assets/11993538/b8e6dca7-ec56-4d76-8c50-3382e5359313)

###### With this PR

![image](https://github.com/R2NorthstarTools/FlightCore/assets/11993538/cc71a60e-b7ba-4914-92b3-60fd0ddb1f77)

---

Closes #384.