### PR TITLE
chore: replace game_scanner usage with winreg

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -36,17 +36,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom 0.2.8",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,7 +82,6 @@ dependencies = [
  "async-recursion",
  "chrono",
  "const_format",
- "game-scanner",
  "json5",
  "libthermite",
  "log",
@@ -107,13 +95,14 @@ dependencies = [
  "serde",
  "serde_json",
  "steamlocate",
- "sysinfo 0.26.9",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-store",
  "tokio",
  "ts-rs",
  "winapi",
+ "winreg 0.11.0",
  "zip",
  "zip-extract",
 ]
@@ -465,12 +454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "case"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,15 +526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -932,21 +906,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
 name = "dirs"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
 dependencies = [
- "dirs-sys 0.4.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -957,17 +922,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1113,18 +1067,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,12 +1108,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1317,27 +1253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "game-scanner"
-version = "1.2.0"
-source = "git+https://github.com/EqualGames/game-scanner.git?rev=94dcbd086a5987361a2847988a060da9b5dd3908#94dcbd086a5987361a2847988a060da9b5dd3908"
-dependencies = [
- "bytes",
- "case",
- "chrono",
- "directories",
- "prost",
- "prost-build",
- "prost-types",
- "rusqlite",
- "serde",
- "serde_json",
- "serde_yaml",
- "sysinfo 0.28.4",
- "url",
- "winreg 0.10.1",
 ]
 
 [[package]]
@@ -1647,18 +1562,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
-dependencies = [
- "hashbrown",
-]
 
 [[package]]
 name = "heck"
@@ -1946,15 +1849,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,17 +1994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "libthermite"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,12 +2025,6 @@ checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2323,12 +2200,6 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
 ]
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
@@ -2801,16 +2672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,61 +2898,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prost"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
-dependencies = [
- "bytes",
- "cfg-if",
- "cmake",
- "heck 0.4.1",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost",
- "prost-types",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
-dependencies = [
- "bytes",
- "prost",
 ]
 
 [[package]]
@@ -3359,20 +3165,6 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
 ]
 
 [[package]]
@@ -3770,18 +3562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
 name = "serialize-to-javascript"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,21 +3838,6 @@ name = "sysinfo"
 version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -5082,17 +4847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5502,15 +5256,6 @@ checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
 dependencies = [
  "nix",
  "winapi",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,9 +48,6 @@ tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", 
 json5 = "0.4.1"
 # Async recursion for recursive mod install
 async-recursion = "1.0.0"
-# Game scanner
-# Use specific commit that updates deprecated library
-game-scanner = { git = "https://github.com/EqualGames/game-scanner.git", rev = "94dcbd086a5987361a2847988a060da9b5dd3908" }
 # For parsing timestamps
 chrono = "0.4.23"
 # TypeScript bindings
@@ -64,9 +61,12 @@ log = "0.4.17"
 zip-extract = "0.1.2"
 # open urls
 open = "3.2.0"
+semver = "1.0"
+
+[target.'cfg(windows)'.dependencies]
 # Windows API stuff
 winapi = "0.3.9"
-semver = "1.0"
+winreg = "0.11.0"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -26,9 +26,6 @@ pub const BLACKLISTED_MODS: [&str; 3] = [
     "ebkr-r2modman",
 ];
 
-// Titanfall2 game IDs on Origin/EA-App
-pub const TITANFALL2_ORIGIN_IDS: [&str; 2] = ["Origin.OFR.50.0001452", "Origin.OFR.50.0001456"];
-
 // Titanfall2 Steam App ID
 pub const TITANFALL2_STEAM_ID: &str = "1237970";
 

--- a/src-tauri/src/platform_specific/windows.rs
+++ b/src-tauri/src/platform_specific/windows.rs
@@ -10,27 +10,24 @@ use crate::check_is_valid_game_path;
 pub fn origin_install_location_detection() -> Result<String, anyhow::Error> {
     #[cfg(target_os = "windows")]
     {
-        let error;
         let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
         match hklm.open_subkey("SOFTWARE\\Respawn\\Titanfall2") {
-            Ok(tf) => match cur_ver.get_value("Install Dir") {
-                Ok(install_dir) => match check_is_valid_game_path(install_dir) {
+            Ok(tf) => {
+                let game_path_str: String = tf.get_value("Install Dir")?;
+
+                match check_is_valid_game_path(&game_path_str) {
                     Ok(()) => {
-                        return Ok(install_dir.to_string());
+                        return Ok(game_path_str.to_string());
                     }
                     Err(err) => {
-                        error = err;
+                        log::warn!("{err}");
                     }
-                },
-                Err(err) => {
-                    error = err;
                 }
-            },
+            }
             Err(err) => {
-                error = err;
+                log::warn!("{err}");
             }
         }
-        log::warn!("{}", error);
     }
 
     Err(anyhow!("No Origin / EA App install path found"))

--- a/src-tauri/src/platform_specific/windows.rs
+++ b/src-tauri/src/platform_specific/windows.rs
@@ -1,34 +1,35 @@
 /// Windows specific code
 use anyhow::{anyhow, Result};
 
-use crate::{check_is_valid_game_path, constants::TITANFALL2_ORIGIN_IDS};
+#[cfg(target_os = "windows")]
+use winreg::{RegKey, enums::HKEY_LOCAL_MACHINE};
+
+use crate::check_is_valid_game_path;
 
 /// Gets Titanfall2 install location on Origin
 pub fn origin_install_location_detection() -> Result<String, anyhow::Error> {
-    // Iterate over known Titanfall2 Origin IDs
-    for origin_id in TITANFALL2_ORIGIN_IDS {
-        match game_scanner::origin::find(origin_id) {
-            // Origin ID found as installed game
-            Ok(game) => {
-                if game.path.is_some() {
-                    let game_path = game.path.unwrap();
-                    let game_path_str = game_path.to_str().unwrap();
-                    match check_is_valid_game_path(game_path_str) {
-                        Ok(()) => {
-                            return Ok(game_path_str.to_string());
-                        }
-                        Err(err) => {
-                            log::warn!("{}", err);
-                            continue; // Not a valid game path
+    #[cfg(target_os = "windows")]
+    {
+        let error;
+        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+        match hklm.open_subkey("SOFTWARE\\Respawn\\Titanfall2") {
+            Ok(tf) => {
+                match cur_ver.get_value("Install Dir") {
+                    Ok(install_dir) => {
+                        match check_is_valid_game_path(install_dir) {
+                            Ok(()) => {
+                                return Ok(install_dir.to_string());
+                            }
+                            Err(err) => { error = err; }
                         }
                     }
+                    Err(err) => { error = err; }
                 }
             }
-            Err(err) => {
-                log::warn!("Couldn't find {origin_id}: {err}")
-            }
+            Err(err) => { error = err; }
         }
+        log::warn!("{}", error);
     }
 
-    Err(anyhow!("No Origin install path found"))
+    Err(anyhow!("No Origin / EA App install path found"))
 }

--- a/src-tauri/src/platform_specific/windows.rs
+++ b/src-tauri/src/platform_specific/windows.rs
@@ -2,7 +2,7 @@
 use anyhow::{anyhow, Result};
 
 #[cfg(target_os = "windows")]
-use winreg::{RegKey, enums::HKEY_LOCAL_MACHINE};
+use winreg::{enums::HKEY_LOCAL_MACHINE, RegKey};
 
 use crate::check_is_valid_game_path;
 
@@ -13,20 +13,22 @@ pub fn origin_install_location_detection() -> Result<String, anyhow::Error> {
         let error;
         let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
         match hklm.open_subkey("SOFTWARE\\Respawn\\Titanfall2") {
-            Ok(tf) => {
-                match cur_ver.get_value("Install Dir") {
-                    Ok(install_dir) => {
-                        match check_is_valid_game_path(install_dir) {
-                            Ok(()) => {
-                                return Ok(install_dir.to_string());
-                            }
-                            Err(err) => { error = err; }
-                        }
+            Ok(tf) => match cur_ver.get_value("Install Dir") {
+                Ok(install_dir) => match check_is_valid_game_path(install_dir) {
+                    Ok(()) => {
+                        return Ok(install_dir.to_string());
                     }
-                    Err(err) => { error = err; }
+                    Err(err) => {
+                        error = err;
+                    }
+                },
+                Err(err) => {
+                    error = err;
                 }
+            },
+            Err(err) => {
+                error = err;
             }
-            Err(err) => { error = err; }
         }
         log::warn!("{}", error);
     }


### PR DESCRIPTION
closes #101

Not compiled on Windows (I don't have a setup for that, so someone else needs to do it).

Error message was updated to reflect this works on Origin and the EA App (should the text be changed to only mention the EA App, since Origin is considered defunct?), though the function name was not updated.

Moved winapi and winreg dependencies into the windows only dependencies, since other systems don't make use of them.



