### PR TITLE
feat: Delete old version when updating mod

### DIFF
--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -435,6 +435,18 @@ pub async fn fc_download_mod_and_install(
     // Get Thunderstore mod author
     let author = thunderstore_mod_string.split('-').next().unwrap();
 
+    // Delete previous version of mod if already installed
+    // This way we ensure that any old files/folders are removed
+    match delete_thunderstore_mod(game_install.clone(), thunderstore_mod_string.to_string()) {
+        Ok(()) => (),
+        Err(err) => {
+            // Error can include the mod being found installed cause this is the first time it's being installed
+            // As such we just ignore any error (but still log it just in case)
+            log::info!("{err}");
+            ()
+        }
+    };
+
     // Extract the mod to the mods directory
     match thermite::core::manage::install_mod(
         author,

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -443,7 +443,6 @@ pub async fn fc_download_mod_and_install(
             // Error can include the mod being found installed cause this is the first time it's being installed
             // As such we just ignore any error (but still log it just in case)
             log::info!("{err}");
-            ()
         }
     };
 


### PR DESCRIPTION
Deletes all Northstar mods based on Thunderstore mod string before installing new version. This way we can clean up old files from mods before installing new version.

Note that the deletion is purposefully only done right before mod is extracted from install. This means it has already been downloaded. This is done to avoid the case where due to a slow internet connection an install fails but the old version of the mod is already removed due to the new logic.

Closes #408