### PR TITLE
fix: delay scrolling the Mods View to prevent it stopping prematurely

### DIFF
--- a/src-vue/src/views/mods/ThunderstoreModsView.vue
+++ b/src-vue/src/views/mods/ThunderstoreModsView.vue
@@ -18,7 +18,7 @@
                         layout="prev, pager, next"
                         :page-size="modsPerPage"
                         :total="modsList.length"
-                        @current-change="(e: number) => currentPageIndex = e - 1"
+                        @update:current-page="onPaginationChange"
                     />
                 </div>
 
@@ -36,7 +36,8 @@
                         layout="prev, pager, next"
                         :page-size="modsPerPage"
                         :total="modsList.length"
-                        @current-change="onBottomPaginationChange"
+                        @update:current-page="onPaginationChange"
+                        @current-change="scrollTop"
                     />
                 </div>
             </div>
@@ -183,9 +184,13 @@ export default defineComponent({
         /**
          * This updates current pagination and scrolls view to the top.
          */
-        onBottomPaginationChange(index: number) {
+        onPaginationChange(index: number) {
             this.currentPageIndex = index - 1;
-            (this.$refs.scrollbar as ScrollbarInstance).scrollTo({ top: 0, behavior: 'smooth' });
+        },
+        scrollTop(index: number) {
+            setTimeout(() => {
+                (this.$refs.scrollbar as ScrollbarInstance).scrollTo({ top: 0, behavior: 'smooth' });
+            }, 100)
         }
     },
     watch: {


### PR DESCRIPTION
With the current logic the modview would change while its trying to scroll, resulting in the scrollbar getting messed up and the scrolling stopping in the middle of the page.

This PR:
- Uses `update:current-page` event for setting the page index
- Uses `current-change` for scrolling
(`update:current-page` is emitted before `current-change`)
- delays the `scrollTo` call by 100ms