### PR TITLE
feat: Run `compareTags()` directly after fetching

### DIFF
--- a/src-vue/src/views/DeveloperView.vue
+++ b/src-vue/src/views/DeveloperView.vue
@@ -234,6 +234,7 @@ export default defineComponent({
                     showNotification("Done", "Fetched tags");
                     this.first_tag = this.ns_release_tags[1];
                     this.second_tag = this.ns_release_tags[0];
+                    this.compareTags();
                 })
                 .catch((error) => {
                     showErrorNotification(error);


### PR DESCRIPTION
In most cases after fetching tags one wants to generate release notes for the two newest. This change saves another click by just running the function directly afterwards.