### PR TITLE
chore: Bump libthermite to `0.6.5`

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1995,9 +1995,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libthermite"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4cb86391198ae3bb90f6fc166593717504f2da58ddd77ef4f3fe643d8752697"
+checksum = "27cd844bbc25676cd14fa9ad04cc40e0f3c4d5c66107ef3a99896db1f81324c0"
 dependencies = [
  "json5",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1995,9 +1995,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libthermite"
-version = "0.5.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8ef144beaf1e683b0ccb2e6e3e14d1e6a8f29e28be3c4fc93376539b28fe97"
+checksum = "b4cb86391198ae3bb90f6fc166593717504f2da58ddd77ef4f3fe643d8752697"
 dependencies = [
  "json5",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ steamlocate = "1.2"
 # Error messages
 anyhow = "1.0"
 # libthermite for Northstar/mod install handling
-libthermite = "0.5.3"
+libthermite = "0.6.4"
 # zip stuff
 zip = "0.6.2"
 # Regex

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ steamlocate = "1.2"
 # Error messages
 anyhow = "1.0"
 # libthermite for Northstar/mod install handling
-libthermite = "0.6.4"
+libthermite = "0.6.5"
 # zip stuff
 zip = "0.6.2"
 # Regex

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -427,9 +427,10 @@ pub async fn fc_download_mod_and_install(
     );
 
     // Download the mod
-    let temp_file = match thermite::core::manage::download_file(download_url, &path) {
-        Ok(f) => TempFile::new(f, path.into()),
-        Err(e) => return Err(e.to_string()),
+    let mut temp_file = TempFile::new(std::fs::File::new(), (&path).into());
+    match thermite::core::manage::download(temp_file.file(), download_url){
+        Ok(_written_bytes) => (),
+        Err(err) => return Err(err.to_string()),
     };
 
     // Get Thunderstore mod author
@@ -441,7 +442,7 @@ pub async fn fc_download_mod_and_install(
         temp_file.file(),
         std::path::Path::new(&mods_directory),
     ) {
-        Ok(()) => (),
+        Ok(_) => (),
         Err(err) => {
             log::warn!("libthermite couldn't install mod {thunderstore_mod_string} due to {err:?}",);
             return Err(err.to_string());

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -427,8 +427,17 @@ pub async fn fc_download_mod_and_install(
     );
 
     // Download the mod
-    let mut temp_file = TempFile::new(std::fs::File::new(), (&path).into());
-    match thermite::core::manage::download(temp_file.file(), download_url){
+    let temp_file = TempFile::new(
+        std::fs::File::options()
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(&path)
+            .map_err(|e| e.to_string())?,
+        (&path).into(),
+    );
+    match thermite::core::manage::download(temp_file.file(), download_url) {
         Ok(_written_bytes) => (),
         Err(err) => return Err(err.to_string()),
     };

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::fs::File;
 use std::time::Duration;
 use std::{cell::RefCell, time::Instant};
 use ts_rs::TS;
@@ -48,8 +49,14 @@ async fn do_install(
     log::info!("Download path: {download_path}");
 
     let last_emit = RefCell::new(Instant::now()); // Keep track of the last time a signal was emitted
-    let nfile = thermite::core::manage::download_with_progress(
-        download_path, // Temp file here?
+    let mut nfile = File::options()
+        .read(true)
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(download_path)?;
+    thermite::core::manage::download_with_progress(
+        &mut nfile, // Temp file here?
         &nmod.url,
         |delta, current, total| {
             if delta != 0 {

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -48,9 +48,9 @@ async fn do_install(
     log::info!("Download path: {download_path}");
 
     let last_emit = RefCell::new(Instant::now()); // Keep track of the last time a signal was emitted
-    let nfile = thermite::core::manage::download_file_with_progress(
+    let nfile = thermite::core::manage::download_with_progress(
+        download_path, // Temp file here?
         &nmod.url,
-        download_path,
         |delta, current, total| {
             if delta != 0 {
                 // Only emit a signal once every 100ms
@@ -85,7 +85,7 @@ async fn do_install(
         .unwrap();
 
     log::info!("Extracting Northstar...");
-    extract(nfile, game_path)?;
+    extract(nfile, game_path)?; // Temp file here?
 
     // Delete old copy
     log::info!("Delete temp folder again");

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -55,7 +55,7 @@ async fn do_install(
         .create(true)
         .open(download_path)?;
     thermite::core::manage::download_with_progress(
-        &mut nfile, // Temp file here?
+        &mut nfile,
         &nmod.url,
         |delta, current, total| {
             if delta != 0 {
@@ -91,7 +91,7 @@ async fn do_install(
         .unwrap();
 
     log::info!("Extracting Northstar...");
-    extract(nfile, game_path)?; // Temp file here?
+    extract(nfile, game_path)?;
 
     // Delete old copy
     log::info!("Delete temp folder again");

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::fs::File;
 use std::time::Duration;
 use std::{cell::RefCell, time::Instant};
 use ts_rs::TS;
@@ -49,7 +48,7 @@ async fn do_install(
     log::info!("Download path: {download_path}");
 
     let last_emit = RefCell::new(Instant::now()); // Keep track of the last time a signal was emitted
-    let mut nfile = File::options()
+    let mut nfile = std::fs::File::options()
         .read(true)
         .write(true)
         .truncate(true)


### PR DESCRIPTION
Bumps `libthermite` to newest version which should hopefully fix #406 

The library had some API changes from `0.5` to `0.6` that need to be accounted for.

Closes #406