### PR TITLE
fix: Address anti-pattern found by newer clippy

### DIFF
--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -297,8 +297,7 @@ fn turn_pr_number_into_link(input: &str, repo: &str) -> String {
     // Extract `Mods/Launcher` from repo title
     let last_line = repo
         .split('/')
-        .rev()
-        .next()
+        .next_back()
         .unwrap()
         .trim_start_matches("Northstar");
     // Extract PR number


### PR DESCRIPTION
Toolchain updated and new clippy managed to find a previously undetected anti-pattern.