### PR TITLE
feat: Implement `to_string` for `ParsedThunderstoreModString`

### DIFF
--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -36,6 +36,12 @@ impl std::str::FromStr for ParsedThunderstoreModString {
     }
 }
 
+impl ToString for ParsedThunderstoreModString {
+    fn to_string(&self) -> String {
+        format!("{}-{}-{}", self.author_name, self.mod_name, self.version)
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ThunderstoreManifest {
     name: String,


### PR DESCRIPTION
Allows printing `ParsedThunderstoreModString` in the Thunderstore mod string format.