### PR TITLE
feat: Compare Flightcore versions as semver

### DIFF
--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -1,4 +1,5 @@
 use crate::constants::APP_USER_AGENT;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;
 use ts_rs::TS;
@@ -58,14 +59,13 @@ pub async fn get_newest_flightcore_version() -> Result<FlightCoreVersion, String
 #[tauri::command]
 pub async fn check_is_flightcore_outdated() -> Result<bool, String> {
     let newest_flightcore_release = get_newest_flightcore_version().await?;
+    let newest_version = Version::parse(&newest_flightcore_release.tag_name[1..]).unwrap();
 
-    // Get version of installed FlightCore...
-    let version = env!("CARGO_PKG_VERSION");
-    // ...and format it
-    let version = format!("v{}", version);
+    // Get version of installed FlightCore
+    let current_version = env!("CARGO_PKG_VERSION");
+    let current_version = Version::parse(current_version).unwrap();
 
-    // TODO: This shouldn't be a string compare but promper semver compare
-    let is_outdated = version != newest_flightcore_release.tag_name;
+    let is_outdated = current_version < newest_version;
 
     // If outdated, check how new the update is
     if is_outdated {

--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -1,5 +1,4 @@
 use crate::constants::APP_USER_AGENT;
-use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;
 use ts_rs::TS;
@@ -59,11 +58,11 @@ pub async fn get_newest_flightcore_version() -> Result<FlightCoreVersion, String
 #[tauri::command]
 pub async fn check_is_flightcore_outdated() -> Result<bool, String> {
     let newest_flightcore_release = get_newest_flightcore_version().await?;
-    let newest_version = Version::parse(&newest_flightcore_release.tag_name[1..]).unwrap();
+    let newest_version = semver::Version::parse(&newest_flightcore_release.tag_name[1..]).unwrap();
 
     // Get version of installed FlightCore
     let current_version = env!("CARGO_PKG_VERSION");
-    let current_version = Version::parse(current_version).unwrap();
+    let current_version = semver::Version::parse(current_version).unwrap();
 
     #[cfg(debug_assertions)]
     let is_outdated = current_version < newest_version;

--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -58,6 +58,7 @@ pub async fn get_newest_flightcore_version() -> Result<FlightCoreVersion, String
 #[tauri::command]
 pub async fn check_is_flightcore_outdated() -> Result<bool, String> {
     let newest_flightcore_release = get_newest_flightcore_version().await?;
+    // Parse version number excluding leading `v`
     let newest_version = semver::Version::parse(&newest_flightcore_release.tag_name[1..]).unwrap();
 
     // Get version of installed FlightCore

--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -65,9 +65,9 @@ pub async fn check_is_flightcore_outdated() -> Result<bool, String> {
     let current_version = env!("CARGO_PKG_VERSION");
     let current_version = Version::parse(current_version).unwrap();
 
-    #[cfg(dev)]
+    #[cfg(debug_assertions)]
     let is_outdated = current_version < newest_version;
-    #[cfg(not(dev))]
+    #[cfg(not(debug_assertions))]
     let is_outdated = current_version != newest_version;
 
     // If outdated, check how new the update is

--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -65,7 +65,10 @@ pub async fn check_is_flightcore_outdated() -> Result<bool, String> {
     let current_version = env!("CARGO_PKG_VERSION");
     let current_version = Version::parse(current_version).unwrap();
 
+    #[cfg(dev)]
     let is_outdated = current_version < newest_version;
+    #[cfg(not(dev))]
+    let is_outdated = current_version != newest_version;
 
     // If outdated, check how new the update is
     if is_outdated {


### PR DESCRIPTION
Worked on PRs before the latest release was tagged causing a notification saying "Update Flightcore, you are running {newer version}. Newest ist {older version}"
