### PR TITLE
i18n: Enable Simplified Chinese translations

### DIFF
--- a/src-vue/src/components/LanguageSelector.vue
+++ b/src-vue/src/components/LanguageSelector.vue
@@ -46,6 +46,10 @@ export default defineComponent({
                 value: 'it',
                 label: 'Italiano'
             },
+            {
+                value: 'zh_Hans',
+                label: '简体中文'
+            },
         ]
     }),
     mounted: async function () {

--- a/src-vue/src/main.ts
+++ b/src-vue/src/main.ts
@@ -17,6 +17,7 @@ import de from "./i18n/lang/de.json";
 import pl from "./i18n/lang/pl.json";
 import ru from "./i18n/lang/ru.json";
 import it from "./i18n/lang/it.json";
+import zh_Hans from "./i18n/lang/zh_Hans.json";
 
 
 const app = createApp(App);
@@ -26,7 +27,7 @@ export const i18n = createI18n({
     locale: 'en',
     fallbackLocale: 'en',
     messages: {
-        en, fr, de, pl, ru, it
+        en, fr, de, pl, ru, it, zh_Hans
     }
 });
 app.use(i18n);


### PR DESCRIPTION
Adds _Simplified Chinese_ to the language dropdown menu in settings.

![image](https://github.com/R2NorthstarTools/FlightCore/assets/40122905/380a3f7c-253f-4026-97b4-087c52fcaf71)
