### PR TITLE
feat: Prevent mods with plugins to be installed

### DIFF
--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -472,6 +472,7 @@ fn fc_sanity_check(input: &&fs::File) -> bool {
         Ok(archive) => archive,
         Err(_) => return false,
     };
+    dbg!();
 
     let mut has_mods = false;
     let mut mod_json_exists = false;
@@ -491,6 +492,15 @@ fn fc_sanity_check(input: &&fs::File) -> bool {
                     if parent_path.parent().unwrap().to_str().unwrap() == "mods" {
                         mod_json_exists = true;
                     }
+                }
+            }
+        }
+
+        if file_path.starts_with("plugins/") {
+            if let Some(name) = file_path.file_name() {
+                if name.to_str().unwrap().contains(".dll") {
+                    log::warn!("Plugin detected, skipping");
+                    return false; // We disallow plugins for now
                 }
             }
         }

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -472,7 +472,6 @@ fn fc_sanity_check(input: &&fs::File) -> bool {
         Ok(archive) => archive,
         Err(_) => return false,
     };
-    dbg!();
 
     let mut has_mods = false;
     let mut mod_json_exists = false;


### PR DESCRIPTION
This is an initial implementation to prevent mods with plugins from being installed.

The goal is to get something like #267 where plugins can be installed if the user opts into installing plugins. Maybe with a warning if they wanna continue etc.