### PR TITLE
feat: Add basic warning on plugin install

### DIFF
--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -500,7 +500,7 @@ fn fc_sanity_check(input: &&fs::File) -> bool {
             if let Some(name) = file_path.file_name() {
                 if name.to_str().unwrap().contains(".dll") {
                     log::warn!("Plugin detected, prompting user");
-                    if plugins::plugin_prompt() == false {
+                    if !plugins::plugin_prompt() {
                         return false; // Plugin detected and user denied install
                     }
                 }

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -12,6 +12,7 @@ use std::string::ToString;
 use std::{fs, path::PathBuf};
 
 mod legacy;
+mod plugins;
 use crate::GameInstall;
 
 #[derive(Debug, Clone)]
@@ -498,8 +499,10 @@ fn fc_sanity_check(input: &&fs::File) -> bool {
         if file_path.starts_with("plugins/") {
             if let Some(name) = file_path.file_name() {
                 if name.to_str().unwrap().contains(".dll") {
-                    log::warn!("Plugin detected, skipping");
-                    return false; // We disallow plugins for now
+                    log::warn!("Plugin detected, prompting user");
+                    if plugins::plugin_prompt() == false {
+                        return false; // Plugin detected and user denied install
+                    }
                 }
             }
         }

--- a/src-tauri/src/mod_management/plugins.rs
+++ b/src-tauri/src/mod_management/plugins.rs
@@ -18,9 +18,9 @@ pub fn plugin_prompt() -> bool {
 
     if dialog.show() {
         log::info!("Accepted plugin install");
-        return true;
+        true
     } else {
         log::warn!("Plugin install cancelled");
-        return false;
+        false
     }
 }

--- a/src-tauri/src/mod_management/plugins.rs
+++ b/src-tauri/src/mod_management/plugins.rs
@@ -1,0 +1,26 @@
+use tauri::api::dialog::blocking::MessageDialogBuilder;
+use tauri::api::dialog::{MessageDialogButtons, MessageDialogKind};
+
+/// Prompt on plugin
+/// Returns:
+/// - true: user accepted plugin install
+/// - false: user denied plugin install
+pub fn plugin_prompt() -> bool {
+    let dialog = MessageDialogBuilder::new(
+        "Plugin in package detected",
+        "This mod contains a plugin. Plugins have unrestricted access to your computer!
+        \nMake sure you trust the author!
+        \n
+        \nPress 'Ok' to continue or 'Cancel' to abort mod installation",
+    )
+    .kind(MessageDialogKind::Warning)
+    .buttons(MessageDialogButtons::OkCancel);
+
+    if dialog.show() {
+        log::info!("Accepted plugin install");
+        return true;
+    } else {
+        log::warn!("Plugin install cancelled");
+        return false;
+    }
+}


### PR DESCRIPTION
Plugins in Northstar have unrestricted device access. As such we want to warn user before installing one with option to abort.

This implementation does not support localisation and the like as it uses Tauri dialogs #418 which are not translated via `vue-i18n`. 
The long term goal is to have the prompt in frontend to allow for localisation but doing it this way for now allow for rapid implementation and deployment ^^

![image](https://github.com/R2NorthstarTools/FlightCore/assets/40122905/cee06616-5ea2-401b-be7e-ed1f962fa0f8)

For testing you can try to install [`cat_or_not-Furnace-1.0.0`](https://northstar.thunderstore.io/package/cat_or_not/Furnace/1.0.0)