### PR TITLE
feat: Add button to DevView to calculate checksums

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "async-recursion",
  "chrono",
  "const_format",
+ "crypto-hash",
  "dirs",
  "glob",
  "json5",
@@ -108,6 +109,7 @@ dependencies = [
  "tauri-plugin-store",
  "tokio",
  "ts-rs",
+ "walkdir",
  "winapi",
  "winreg 0.11.0",
  "zip",
@@ -596,6 +598,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "commoncrypto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
+dependencies = [
+ "commoncrypto-sys",
+]
+
+[[package]]
+name = "commoncrypto-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +765,18 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-hash"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
+dependencies = [
+ "commoncrypto",
+ "hex 0.3.2",
+ "openssl",
+ "winapi",
 ]
 
 [[package]]
@@ -1595,6 +1627,12 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
 name = "hex"
@@ -3465,7 +3503,7 @@ checksum = "360ee3270f7a4a1eee6c667f7d38360b995431598a73b740dfe420da548d9cc9"
 dependencies = [
  "debugid",
  "getrandom 0.2.10",
- "hex",
+ "hex 0.4.3",
  "serde",
  "serde_json",
  "thiserror",
@@ -3545,7 +3583,7 @@ checksum = "21e47d95bc83ed33b2ecf84f4187ad1ab9685d18ff28db000c99deac8ce180e3"
 dependencies = [
  "base64 0.21.2",
  "chrono",
- "hex",
+ "hex 0.4.3",
  "indexmap 1.9.3",
  "serde",
  "serde_json",
@@ -5331,7 +5369,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "hex",
+ "hex 0.4.3",
  "nix",
  "once_cell",
  "ordered-stream",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,6 +65,10 @@ semver = "1.0"
 # simplified filesystem access
 glob = "0.3.1"
 dirs = "5"
+# Walk directories
+walkdir = "2.3"
+# Crypto stuff like checksum calculation
+crypto-hash = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 # Windows API stuff

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -156,6 +156,7 @@ fn main() {
             github::pull_requests::get_launcher_download_link,
             close_application,
             development::install_git_main,
+            development::calculate_checksums_gameinstall,
             get_available_northstar_versions,
         ])
         .run(tauri::generate_context!())


### PR DESCRIPTION
Adds button to DevView to calculate checksum of files in game install location. The results are then sent to text field in frontend from where it can be copy/pasted.

![image](https://github.com/R2NorthstarTools/FlightCore/assets/40122905/9495b05a-9925-4a7f-861c-e916c728fe51)

The idea behind this being to get contributors and/or playtesters to use it to crowdsource the checksums of various gamefiles to then roll our own game verification code as part of the repair window.

(Yes I'm aware that game files can be verified via Steam / EA App but that excludes files we add like `wsock32.dll` and I also want everything self contained so that in the long run I could add a "troubleshoot my game" button that runs functions for detecting the most common issues)