### PR TITLE
feat: Add button to forcefully terminate Northstar

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -142,6 +142,7 @@ fn main() {
             github::release_notes::get_newest_flightcore_version,
             mod_management::delete_northstar_mod,
             util::get_server_player_count,
+            util::kill_northstar,
             mod_management::delete_thunderstore_mod,
             install_northstar_proton_wrapper,
             uninstall_northstar_proton_wrapper,

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -74,10 +74,12 @@ pub async fn kill_northstar() -> Result<(), String> {
 
 
     for process in s.processes_by_exact_name("Titanfall2.exe") {
+        log::info!("Killing Process {}", process.pid())
         process.kill();
     }
 
     for process in s.processes_by_exact_name("NorthstarLauncher.exe") {
+        log::info!("Killing Process {}", process.pid())
         process.kill();
     }
 

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use sysinfo::{SystemExt, ProcessExt};
+use sysinfo::{ProcessExt, SystemExt};
 use zip::ZipArchive;
 
 use crate::constants::{APP_USER_AGENT, MASTER_SERVER_URL, SERVER_BROWSER_ENDPOINT};
@@ -72,14 +72,13 @@ pub async fn kill_northstar() -> Result<(), String> {
 
     let s = sysinfo::System::new_all();
 
-
     for process in s.processes_by_exact_name("Titanfall2.exe") {
-        log::info!("Killing Process {}", process.pid())
+        log::info!("Killing Process {}", process.pid());
         process.kill();
     }
 
     for process in s.processes_by_exact_name("NorthstarLauncher.exe") {
-        log::info!("Killing Process {}", process.pid())
+        log::info!("Killing Process {}", process.pid());
         process.kill();
     }
 

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use sysinfo::SystemExt;
+use sysinfo::{SystemExt, ProcessExt};
 use zip::ZipArchive;
 
 use crate::constants::{APP_USER_AGENT, MASTER_SERVER_URL, SERVER_BROWSER_ENDPOINT};
@@ -62,6 +62,26 @@ pub async fn get_server_player_count() -> Result<(i32, usize), String> {
     log::info!("server_count:       {}", server_count);
 
     Ok((total_player_count, server_count))
+}
+
+#[tauri::command]
+pub async fn kill_northstar() -> Result<(), String> {
+    if !check_northstar_running() {
+        return Err("Northstar is not running".to_string());
+    }
+
+    let s = sysinfo::System::new_all();
+
+
+    for process in s.processes_by_exact_name("Titanfall2.exe") {
+        process.kill();
+    }
+
+    for process in s.processes_by_exact_name("NorthstarLauncher.exe") {
+        process.kill();
+    }
+
+    Ok(())
 }
 
 /// Copied from `papa` source code and modified

--- a/src-vue/src/views/DeveloperView.vue
+++ b/src-vue/src/views/DeveloperView.vue
@@ -74,6 +74,10 @@
                 Get installed mods
             </el-button>
 
+            <el-button type="primary" @click="killNorthstar">
+                Kill Northstar
+            </el-button>
+
             <h3>Testing</h3>
             <pull-requests-selector />
 
@@ -216,6 +220,16 @@ export default defineComponent({
                 // Just a visual indicator that it worked
                 showNotification('Success');
             })
+                .catch((error) => {
+                    showErrorNotification(error);
+                });
+        },
+        async killNorthstar() {
+            await invoke("kill_northstar")
+                .then((message) => {
+                    // Just a visual indicator that it worked
+                    showNotification('Success');
+                })
                 .catch((error) => {
                     showErrorNotification(error);
                 });


### PR DESCRIPTION
At times Northstar (or rather Titanfall2 in general) locks up completely and needs to be killed.
This adds a button to kill Titanfall2.exe or NorthstarLauncher.exe to the Dev View.

Untested.