### PR TITLE
Extract Northstar into temporary location before installing

### DIFF
--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -5,7 +5,7 @@ use std::{cell::RefCell, time::Instant};
 use ts_rs::TS;
 
 use crate::constants::TITANFALL2_STEAM_ID;
-use crate::{util::extract, GameInstall, InstallType};
+use crate::{util::{extract,move_dir_all}, GameInstall, InstallType};
 
 #[cfg(target_os = "windows")]
 use crate::platform_specific::windows;
@@ -40,10 +40,7 @@ async fn do_install(
     let download_directory = format!("{}/download-dir", temp_dir);
     let extract_directory = format!("{}/extract-dir", temp_dir);
 
-    log::info!(
-        "Attempting to create temporary directory {}",
-        temp_dir
-    );
+    log::info!("Attempting to create temporary directory {}", temp_dir);
     std::fs::create_dir_all(download_directory.clone())?;
     std::fs::create_dir_all(extract_directory.clone())?;
 
@@ -100,7 +97,16 @@ async fn do_install(
 
     for entry in std::fs::read_dir(extract_directory).unwrap() {
         let entry = entry.unwrap();
-        let destination = format!("{}/{}", game_path, entry.path().file_name().unwrap().to_str().unwrap().to_string());
+        let destination = format!(
+            "{}/{}",
+            game_path.display(),
+            entry
+                .path()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+        );
 
         log::info!("Installing {}", entry.path().display());
         if !entry.file_type().unwrap().is_dir() {

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -5,7 +5,10 @@ use std::{cell::RefCell, time::Instant};
 use ts_rs::TS;
 
 use crate::constants::TITANFALL2_STEAM_ID;
-use crate::{util::{extract,move_dir_all}, GameInstall, InstallType};
+use crate::{
+    util::{extract, move_dir_all},
+    GameInstall, InstallType,
+};
 
 #[cfg(target_os = "windows")]
 use crate::platform_specific::windows;
@@ -100,12 +103,7 @@ async fn do_install(
         let destination = format!(
             "{}/{}",
             game_path.display(),
-            entry
-                .path()
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
+            entry.path().file_name().unwrap().to_str().unwrap()
         );
 
         log::info!("Installing {}", entry.path().display());

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -39,7 +39,7 @@ async fn do_install(
     game_path: &std::path::Path,
 ) -> Result<()> {
     let filename = format!("northstar-{}.zip", nmod.version);
-    let temp_dir = format!("{}/___flightcore-temp-dir", game_path.display());
+    let temp_dir = format!("{}/___flightcore-temp-download-dir", game_path.display());
     let download_directory = format!("{}/download-dir", temp_dir);
     let extract_directory = format!("{}/extract-dir", temp_dir);
 

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -39,7 +39,7 @@ async fn do_install(
     game_install: GameInstall,
 ) -> Result<()> {
     let filename = format!("northstar-{}.zip", nmod.version);
-    let temp_dir = format!("{}/___flightcore-temp", game_path.display());
+    let temp_dir = format!("{}/___flightcore-temp", game_install.game_path);
     let download_directory = format!("{}/download-dir", temp_dir);
     let extract_directory = format!("{}/extract-dir", temp_dir);
 
@@ -102,7 +102,7 @@ async fn do_install(
         let entry = entry.unwrap();
         let destination = format!(
             "{}/{}",
-            game_install.game_path.display(),
+            game_install.game_path,
             entry.path().file_name().unwrap().to_str().unwrap()
         );
 

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -144,6 +144,7 @@ pub fn check_northstar_running() -> bool {
     x
 }
 
+/// Copies a folder and all its contents to a new location
 #[allow(dead_code)]
 pub fn copy_dir_all(
     src: impl AsRef<std::path::Path>,
@@ -162,6 +163,8 @@ pub fn copy_dir_all(
     Ok(())
 }
 
+/// Moves a folders file structure to a new location
+/// Old folders are not removed
 pub fn move_dir_all(
     src: impl AsRef<std::path::Path>,
     dst: impl AsRef<std::path::Path>,

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -144,6 +144,7 @@ pub fn check_northstar_running() -> bool {
     x
 }
 
+#[allow(dead_code)]
 pub fn copy_dir_all(
     src: impl AsRef<std::path::Path>,
     dst: impl AsRef<std::path::Path>,

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -143,3 +143,38 @@ pub fn check_northstar_running() -> bool {
         || s.processes_by_name("Titanfall2.exe").next().is_some();
     x
 }
+
+pub fn copy_dir_all(
+    src: impl AsRef<std::path::Path>,
+    dst: impl AsRef<std::path::Path>,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(&dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            std::fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+pub fn move_dir_all(
+    src: impl AsRef<std::path::Path>,
+    dst: impl AsRef<std::path::Path>,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(&dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            move_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+            std::fs::remove_dir(entry.path())?;
+        } else {
+            std::fs::rename(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
This would allow preprocessing to be done ahead of time, like moving the dll into the profile or renaming the profile.

Nothing is actually done yet, because of some missing bits in Northstar.