### PR TITLE
Move DLL into Profile for non default Profiles

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -52,3 +52,9 @@ pub const NORTHSTAR_RELEASE_REPO_NAME: &str = "R2Northstar/Northstar";
 // URL to launcher commits API URL
 pub const NS_LAUNCHER_COMMITS_API_URL: &str =
     "https://api.github.com/repos/R2Northstar/NorthstarLauncher/commits";
+
+// Filename of DLL that Northstar uses
+pub const NORTHSTAR_DLL: &str = "Northstar.dll";
+
+// Profile that Northstar defaults to and ships with
+pub const NORTHSTAR_DEFAULT_PROFILE: &str = "R2Northstar";

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use std::{cell::RefCell, time::Instant};
 use ts_rs::TS;
 
-use crate::constants::TITANFALL2_STEAM_ID;
+use crate::constants::{NORTHSTAR_DEFAULT_PROFILE, NORTHSTAR_DLL, TITANFALL2_STEAM_ID};
 use crate::{
     util::{extract, move_dir_all},
     GameInstall, InstallType,
@@ -96,18 +96,19 @@ async fn do_install(
     log::info!("Extracting Northstar...");
     extract(nfile, std::path::Path::new(&extract_directory))?;
 
-    if game_install.profile != "R2Northstar" {
+
+    if game_install.profile != NORTHSTAR_DEFAULT_PROFILE {
         // We are using a non standard Profile, we must:
         // - move the DLL
         // - rename the Profile
 
         // Move DLL into default Profile
-        let old_dll_path = format!("{}/Northstar.dll", extract_directory);
-        let new_dll_path = format!("{}/R2Northstar/Northstar.dll", extract_directory);
+        let old_dll_path = format!("{}/{}", extract_directory, NORTHSTAR_DLL);
+        let new_dll_path = format!("{}/R2Northstar/{}", extract_directory, NORTHSTAR_DLL);
         std::fs::rename(old_dll_path, new_dll_path)?;
 
         // rename default Profile
-        let old_profile_path = format!("{}/R2Northstar/", extract_directory);
+        let old_profile_path = format!("{}/{}/", extract_directory, NORTHSTAR_DEFAULT_PROFILE);
         let new_profile_path = format!("{}/{}/", extract_directory, game_install.profile);
         std::fs::rename(old_profile_path, new_profile_path)?;
     }

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -96,6 +96,22 @@ async fn do_install(
     log::info!("Extracting Northstar...");
     extract(nfile, std::path::Path::new(&extract_directory))?;
 
+    if game_install.profile != "R2Northstar" {
+        // We are using a non standard Profile, we must:
+        // - move the DLL
+        // - rename the Profile
+
+        // Move DLL into default Profile
+        let old_dll_path = format!("{}/Northstar.dll", extract_directory);
+        let new_dll_path = format!("{}/R2Northstar/Northstar.dll", extract_directory);
+        std::fs::rename(old_dll_path, new_dll_path)?;
+
+        // rename default Profile
+        let old_profile_path = format!("{}/R2Northstar/", extract_directory);
+        let new_profile_path = format!("{}/{}/", extract_directory, game_install.profile);
+        std::fs::rename(old_profile_path, new_profile_path)?;
+    }
+
     log::info!("Installing Northstar...");
 
     for entry in std::fs::read_dir(extract_directory).unwrap() {

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -103,12 +103,12 @@ async fn do_install(
         // - move the DLL
         // - rename the Profile
 
-        // Move DLL into default Profile
+        // Move DLL into the default R2Northstar Profile
         let old_dll_path = format!("{}/{}", extract_directory, NORTHSTAR_DLL);
-        let new_dll_path = format!("{}/R2Northstar/{}", extract_directory, NORTHSTAR_DLL);
+        let new_dll_path = format!("{}/{}/{}", extract_directory, NORTHSTAR_DEFAULT_PROFILE, NORTHSTAR_DLL);
         std::fs::rename(old_dll_path, new_dll_path)?;
 
-        // rename default Profile
+        // rename default R2Northstar Profile to the profile we want to use
         let old_profile_path = format!("{}/{}/", extract_directory, NORTHSTAR_DEFAULT_PROFILE);
         let new_profile_path = format!("{}/{}/", extract_directory, game_install.profile);
         std::fs::rename(old_profile_path, new_profile_path)?;

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -105,7 +105,10 @@ async fn do_install(
 
         // Move DLL into the default R2Northstar Profile
         let old_dll_path = format!("{}/{}", extract_directory, NORTHSTAR_DLL);
-        let new_dll_path = format!("{}/{}/{}", extract_directory, NORTHSTAR_DEFAULT_PROFILE, NORTHSTAR_DLL);
+        let new_dll_path = format!(
+            "{}/{}/{}",
+            extract_directory, NORTHSTAR_DEFAULT_PROFILE, NORTHSTAR_DLL
+        );
         std::fs::rename(old_dll_path, new_dll_path)?;
 
         // rename default R2Northstar Profile to the profile we want to use

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -96,7 +96,8 @@ async fn do_install(
     log::info!("Extracting Northstar...");
     extract(nfile, std::path::Path::new(&extract_directory))?;
 
-
+    // Prepare Northstar for Installation
+    log::info!("Preparing Northstar...");
     if game_install.profile != NORTHSTAR_DEFAULT_PROFILE {
         // We are using a non standard Profile, we must:
         // - move the DLL


### PR DESCRIPTION
This is done so that with profiles we can run different versions of Northstar which would use different versions of the `Northstar.dll`