### PR TITLE
fix: Give thunderstore mod card images a background color

### DIFF
--- a/src-vue/src/components/ThunderstoreModCard.vue
+++ b/src-vue/src/components/ThunderstoreModCard.vue
@@ -312,4 +312,8 @@ export default defineComponent({
     margin-left: 10px;
     height: auto;
 }
+
+.image {
+    background-color: lightgray;
+}
 </style>


### PR DESCRIPTION
Give thunderstore mod card images a background color to prevent alpha issues


**Before:**
![image](https://github.com/R2NorthstarTools/FlightCore/assets/15076013/be6e9752-4579-48e9-af04-1935a1857d46)

**After:**
![image](https://github.com/R2NorthstarTools/FlightCore/assets/15076013/64a2573b-a42b-4e08-8eb3-b9d491705ab1)

Not noticable on images with no alpha, chose lightgrey because of the lack of contrast.