### PR TITLE
chore: Do not specify patch version for `sentry-log`

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ tauri = { version = "1.4", features = ["api-all", "dialog", "updater"] }
 tokio = { version = "1", features = ["full"] }
 # Sentry (crash) logging
 sentry = "0.31"
-sentry-log = "0.30.0"
+sentry-log = "0.30"
 # Find steam games
 steamlocate = "1.2"
 # Error messages


### PR DESCRIPTION
Allow to use whatever is newest patch release.

For some reason I dropped specifying the patch version for `sentry` but still specified it for `sentry-log`. Given that the two kinda go together we should either specify patch version for both or neither. I'm tending towards the latter ^^