### PR TITLE
feat: Strip trailing newline from release notes

### DIFF
--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -180,7 +180,7 @@ fn generate_flightcore_release_notes(commits: Vec<String>) -> String {
         }
     }
 
-    let release_notes = release_notes.trim_end_matches("\n").to_string();
+    let release_notes = release_notes.trim_end_matches('\n').to_string();
     release_notes
 }
 

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -180,6 +180,7 @@ fn generate_flightcore_release_notes(commits: Vec<String>) -> String {
         }
     }
 
+    let release_notes = release_notes.trim_end_matches("\n").to_string();
     release_notes
 }
 


### PR DESCRIPTION
Generating release notes for FlightCore always had two trailing newlines due to the way the code is setup to expect more categories.

Had to remove them every time I made release and it got annoying.

Simply strip the remaining newlines at the end of the release notes to solve that :>