### PR TITLE
fix: try deleting thunderstore package before deleting mod

### DIFF
--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -686,7 +686,12 @@ pub fn delete_northstar_mod(game_install: GameInstall, nsmod_name: String) -> Re
         // Installed mod matches specified mod
         if installed_ns_mod.name == nsmod_name {
             // Delete folder
-            return match delete_thunderstore_mod(game_install, installed_ns_mod.thunderstore_mod_string.or(Some("".to_string())).unwrap()) {
+            return match delete_thunderstore_mod(
+                game_install,
+                installed_ns_mod
+                    .thunderstore_mod_string
+                    .unwrap_or("".to_string()),
+            ) {
                 Ok(_) => Ok(()),
                 Err(_) => delete_mod_folder(&installed_ns_mod.directory),
             };

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -679,14 +679,17 @@ pub fn delete_northstar_mod(game_install: GameInstall, nsmod_name: String) -> Re
     }
 
     // Get installed mods
-    let installed_ns_mods = get_installed_mods_and_properties(game_install)?;
+    let installed_ns_mods = get_installed_mods_and_properties(game_install.clone())?;
 
     // Get folder name based on northstarmods
     for installed_ns_mod in installed_ns_mods {
         // Installed mod matches specified mod
         if installed_ns_mod.name == nsmod_name {
             // Delete folder
-            return delete_mod_folder(&installed_ns_mod.directory);
+            return match delete_thunderstore_mod(game_install, installed_ns_mod.thunderstore_mod_string.or(Some("".to_string())).unwrap()) {
+                Ok(_) => Ok(()),
+                Err(_) => delete_mod_folder(&installed_ns_mod.directory),
+            };
         }
     }
 


### PR DESCRIPTION
resolves #492 
When deleting a package from the local mod view it only deletes the mods folder.

This PR tries delete the thunderstore mod first and if that fails it tries deleting the mod folder