### PR TITLE
chore: Set regex to correct version in Cargo.toml

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ libthermite = { version = "0.7.0-beta", features = ["proton"] }
 # zip stuff
 zip = "0.6.2"
 # Regex
-regex = "1.6.0"
+regex = "1.9"
 # Read out running application process names
 sysinfo = "0.29.7"
 # HTTP requests


### PR DESCRIPTION
No clue how it happened but `Cargo.toml` and `Cargo.lock` do not agree on the version of `regex`.