### PR TITLE
chore: Do not specify patch version for `log`

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,7 +56,7 @@ ts-rs = "6.1"
 const_format = "0.2.30"
 # Logging libraries
 pretty_env_logger = "0.5.0"
-log = "0.4.17"
+log = "0.4"
 # Extracting zip files easily
 zip-extract = "0.1.2"
 # open urls


### PR DESCRIPTION
Allow to use whatever is newest patch release.