### PR TITLE
fix: Remove hashes around raw string literal

### DIFF
--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -184,7 +184,7 @@ pub async fn install_northstar(
         Err(err) => {
             if game_path
                 .to_lowercase()
-                .contains(&r#"C:\Program Files\"#.to_lowercase())
+                .contains(&r"C:\Program Files\".to_lowercase())
             // default is `C:\Program Files\EA Games\Titanfall2`
             {
                 return Err(


### PR DESCRIPTION
Remove hashes around raw string literal clippy said they are "unnecessary"

Should resolve current CI failure