### PR TITLE
i18n: Enable Spanish translations

### DIFF
--- a/src-vue/src/components/LanguageSelector.vue
+++ b/src-vue/src/components/LanguageSelector.vue
@@ -35,6 +35,10 @@ export default defineComponent({
                 label: 'Deutsch'
             },
             {
+                value: 'es',
+                label: 'Español'
+            },
+            {
                 value: 'pl',
                 label: 'polski'
             },

--- a/src-vue/src/main.ts
+++ b/src-vue/src/main.ts
@@ -15,6 +15,7 @@ import en from "./i18n/lang/en.json";
 import fr from "./i18n/lang/fr.json";
 import da from "./i18n/lang/da.json";
 import de from "./i18n/lang/de.json";
+import es from "./i18n/lang/es.json";
 import pl from "./i18n/lang/pl.json";
 import ru from "./i18n/lang/ru.json";
 import it from "./i18n/lang/it.json";
@@ -28,7 +29,7 @@ export const i18n = createI18n({
     locale: 'en',
     fallbackLocale: 'en',
     messages: {
-        en, fr, da, de, pl, ru, it, zh_Hans
+        en, fr, da, de, es, pl, ru, it, zh_Hans
     }
 });
 app.use(i18n);


### PR DESCRIPTION
Adds _Spanish_ to the language dropdown menu in settings.

![image](https://github.com/R2NorthstarTools/FlightCore/assets/40122905/168dc70a-162a-418f-a66d-545c1a58c95b)
