### PR TITLE
build: Add npm packge in root dir to bot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,14 @@
 
 version: 2
 updates:
+  # Root NPM package
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore: "
+
   # NPM packages
   - package-ecosystem: 'npm'
     directory: '/src-vue'


### PR DESCRIPTION
The repo root dir also has a `package.json` which contains the necessary build tools. We wanna keep those up-to-date as well.