### PR TITLE
feat: Add button to delete profile

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -160,6 +160,7 @@ fn main() {
             get_available_northstar_versions,
             northstar::profile::fetch_profiles,
             northstar::profile::validate_profile,
+            northstar::profile::delete_profile,
         ])
         .run(tauri::generate_context!())
     {

--- a/src-tauri/src/northstar/profile.rs
+++ b/src-tauri/src/northstar/profile.rs
@@ -74,3 +74,20 @@ pub fn validate_profile(game_install: GameInstall, profile: String) -> bool {
 
     profile_dir.is_dir()
 }
+
+#[tauri::command]
+pub fn delete_profile(game_install: GameInstall, profile: String) -> Result<(), String> {
+    // Check if the Profile actually exists
+    if !validate_profile(game_install.clone(), profile.clone()) {
+        return Err(format!("{} is not a valid Profile", profile));
+    }
+
+    log::info!("Deleting Profile {}", profile);
+
+    let profile_path = format!("{}/{}", game_install.game_path, profile);
+
+    match std::fs::remove_dir_all(profile_path) {
+        Ok(()) => Ok(()),
+        Err(err) => Err(format!("Failed to delete Profile: {}", err)),
+    }
+}

--- a/src-vue/src/i18n/lang/en.json
+++ b/src-vue/src/i18n/lang/en.json
@@ -11,6 +11,7 @@
         "yes": "Yes",
         "no": "No",
         "error": "Error",
+        "confirm": "Confirm",
         "cancel": "Cancel",
         "informationShort": "Info",
         "downloading": "Downloading",
@@ -115,7 +116,10 @@
             "edit": "Edit Profiles",
 
             "dialog": {
-                "title": "Profiles"
+                "title": "Profiles",
+                "delete_confirm": "Are you sure to delete this profile?",
+                "delete": "Delete",
+                "clone": "Clone"
             }
         },
 

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -6,6 +6,23 @@
     >
         <el-table :data="availableProfiles" >
             <el-table-column prop="name" label="Name" />
+            <el-table-column align="right">
+              <template #default="scope">
+                <el-popconfirm
+                    v-if="scope.row.name != 'R2Northstar'"
+                    :title="$t('settings.profile.dialog.delete_confirm')"
+                    :confirm-button-text="$t('generic.yes')"
+                    :cancel-button-text="$t('generic.no')"
+                    @confirm="deleteProfile(scope.row.name)"
+                >
+                    <template #reference>
+                        <el-button type="danger">
+                            {{ $t('settings.profile.dialog.delete') }}
+                        </el-button>
+                    </template>
+                </el-popconfirm>
+              </template>
+          </el-table-column>
         </el-table>
     </el-dialog>
 
@@ -256,6 +273,24 @@ export default defineComponent({
                     console.error(error);
                     showErrorNotification(error);
                 });
+        },
+        async deleteProfile(profile: string) {
+            let store = this.$store;
+            await invoke("delete_profile", {
+                gameInstall: store.state.game_install,
+                profile: profile,
+            }).then(async (message) => {
+                if (profile == store.state.game_install.profile)
+                {
+                    // trying to delete the active profile, lets switch to the default profile
+                    await this.switchProfile("R2Northstar");
+                }
+                store.commit('fetchProfiles');
+                showNotification('Success');
+            }).catch((error) => {
+                console.error(error);
+                showErrorNotification(error);
+            });
         },
     },
     mounted() {


### PR DESCRIPTION
This adds a button and corresponding logic to delete an existing profile

![image](https://github.com/R2NorthstarTools/FlightCore/assets/40122905/864e48ae-c31f-4159-a237-a6bb9a5e797c)


Spliced out from #444