### PR TITLE
feat: Notification menu

### DIFF
--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -34,9 +34,6 @@ export default {
     this.$root!.$i18n.locale = lang;
   },
   methods: {
-    async toggleMaximize() {
-      await appWindow.toggleMaximize();
-    },
     minimize() {
       appWindow.minimize()
     },
@@ -77,7 +74,6 @@ export default {
       <!-- Window controls -->
       <div id="fc_window__controls">
         <el-button color="white" icon="SemiSelect" @click="minimize" circle />
-        <el-button color="white" icon="FullScreen" @click="toggleMaximize" circle />
         <el-button color="white" icon="CloseBold" @click="close" circle />
       </div>
     </nav>

--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -8,9 +8,11 @@ import { appWindow } from '@tauri-apps/api/window';
 import { store } from './plugins/store';
 import { Store } from 'tauri-plugin-store-api';
 import { invoke } from "@tauri-apps/api";
+import NotificationButton from "./components/NotificationButton.vue";
 
 export default {
   components: {
+      NotificationButton,
       ChangelogView,
       DeveloperView,
       PlayView,
@@ -73,6 +75,7 @@ export default {
 
       <!-- Window controls -->
       <div id="fc_window__controls">
+        <NotificationButton />
         <el-button color="white" icon="SemiSelect" @click="minimize" circle />
         <el-button color="white" icon="CloseBold" @click="close" circle />
       </div>
@@ -119,7 +122,7 @@ export default {
   height: 100%;
   background-color: transparent;
   float: left;
-  width: calc(100% - 148px); /* window controls container width */
+  width: calc(100% - 168px); /* window controls container width */
 }
 
 #fc__menu_items .el-menu-item, #fc__menu_items .el-sub-menu__title {

--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -170,7 +170,9 @@ export default {
   height: 100%;
 }
 
-#fc_window__controls > button, #fc_window__controls > .el-dropdown > button {
+#fc_window__controls > button,
+#fc_window__controls > .el-dropdown > button,
+#fc_window__controls > .el-dropdown > .el-badge > button {
   color: white;
   font-size: 20px;
   margin: auto 5px;
@@ -179,16 +181,24 @@ export default {
   height: 100%;
 }
 
-#fc_window__controls > button:hover, #fc_window__controls > .el-dropdown > button:hover {
+#fc_window__controls > button:hover,
+#fc_window__controls > .el-dropdown > button:hover,
+#fc_window__controls > .el-dropdown > .el-badge > button:hover {
   color: #c6c9ce;
 }
 
-#fc_window__controls > button:active, #fc_window__controls > .el-dropdown > button:active {
+#fc_window__controls > button:active,
+#fc_window__controls > .el-dropdown > button:active {
   color: #56585a;
 }
 
 #fc_window__controls > button:last-of-type {
   margin-right: 15px;
+}
+
+sup {
+  transform: translate(-10px, 5px) !important;
+  border: none !important;
 }
 
 </style>

--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -170,7 +170,7 @@ export default {
   height: 100%;
 }
 
-#fc_window__controls > button {
+#fc_window__controls > button, #fc_window__controls > .el-dropdown > button {
   color: white;
   font-size: 20px;
   margin: auto 5px;
@@ -179,11 +179,11 @@ export default {
   height: 100%;
 }
 
-#fc_window__controls > button:hover {
+#fc_window__controls > button:hover, #fc_window__controls > .el-dropdown > button:hover {
   color: #c6c9ce;
 }
 
-#fc_window__controls > button:active {
+#fc_window__controls > button:active, #fc_window__controls > .el-dropdown > button:active {
   color: #56585a;
 }
 

--- a/src-vue/src/components/NotificationButton.vue
+++ b/src-vue/src/components/NotificationButton.vue
@@ -7,6 +7,7 @@
         <template #dropdown>
             <el-dropdown-menu>
                 <el-alert
+                    v-if="notifications.length != 0"
                     v-for="notification in notifications"
                     :key="JSON.stringify(notification)"
                     :title="notification.title"
@@ -15,6 +16,15 @@
                     show-icon
                     style="width: 300px"
                 />
+                <el-result
+                    v-else
+                    icon="success"
+                    title="Up-to-date"
+                    sub-title="Nothing to see here!"
+                >
+                    <template #icon>
+                    </template>
+                </el-result>
             </el-dropdown-menu>
         </template>
     </el-dropdown>

--- a/src-vue/src/components/NotificationButton.vue
+++ b/src-vue/src/components/NotificationButton.vue
@@ -6,9 +6,9 @@
                 <el-alert
                     v-for="notification in notifications"
                     :key="JSON.stringify(notification)"
-                    title="success alert"
-                    type="success"
-                    description="more text description"
+                    :title="notification.title"
+                    :description="notification.text"
+                    :type="notification.type"
                     show-icon
                     style="width: 300px"
                 />

--- a/src-vue/src/components/NotificationButton.vue
+++ b/src-vue/src/components/NotificationButton.vue
@@ -20,8 +20,8 @@
                 <el-result
                     v-else
                     icon="success"
-                    title="Up-to-date"
-                    sub-title="Nothing to see here!"
+                    :title="i18n.global.tc('notification.no_new.title')"
+                    :sub-title="i18n.global.tc('notification.no_new.text')"
                 >
                     <template #icon>
                     </template>
@@ -34,6 +34,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import {Notification} from '../plugins/modules/notifications';
+import {i18n} from "../main";
 
 export default defineComponent({
     name: 'NotificationButton',
@@ -42,6 +43,9 @@ export default defineComponent({
         counter: 0
     }),
     computed: {
+        i18n() {
+            return i18n
+        },
         notifications(): Notification[] {
             return this.$store.state.notifications.notifications;
         }

--- a/src-vue/src/components/NotificationButton.vue
+++ b/src-vue/src/components/NotificationButton.vue
@@ -1,10 +1,25 @@
 <template>
-    <el-button color="white" icon="BellFilled" circle />
+    <el-dropdown trigger="click" placement="bottom-end" max-height="280" popper-class="fc_popper">
+        <el-button color="white" icon="BellFilled" circle />
+        <template #dropdown>
+            <el-dropdown-menu>
+                <el-alert
+                    v-for="i in 10" :key="i"
+                    title="success alert"
+                    type="success"
+                    description="more text description"
+                    show-icon
+                    style="width: 300px"
+                />
+            </el-dropdown-menu>
+        </template>
+    </el-dropdown>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { Store } from 'tauri-plugin-store-api';
+import {Check, CircleCheck, CirclePlus, CirclePlusFilled, Plus} from "@element-plus/icons-vue";
 const persistentStore = new Store('flight-core-settings.json');
 
 export default defineComponent({
@@ -13,13 +28,37 @@ export default defineComponent({
 
     }),
     methods: {
+        CircleCheck() {
+            return CircleCheck
+        },
+        Check() {
+            return Check
+        },
+        CirclePlus() {
+            return CirclePlus
+        },
+        CirclePlusFilled() {
+            return CirclePlusFilled
+        },
+        Plus() {
+            return Plus
+        }
 
     }
 })
 </script>
 
 <style scoped>
+.el-dropdown {
+    height: 100%;
+    max-height: 300px;
+}
+
 .el-button {
-    margin-right: 25px !important;
+    margin: auto 25px auto 0 !important;
+}
+
+.el-alert {
+    margin: 5px 10px 5px 5px;
 }
 </style>

--- a/src-vue/src/components/NotificationButton.vue
+++ b/src-vue/src/components/NotificationButton.vue
@@ -4,7 +4,8 @@
         <template #dropdown>
             <el-dropdown-menu>
                 <el-alert
-                    v-for="i in 10" :key="i"
+                    v-for="notification in notifications"
+                    :key="JSON.stringify(notification)"
                     title="success alert"
                     type="success"
                     description="more text description"
@@ -18,33 +19,15 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Store } from 'tauri-plugin-store-api';
-import {Check, CircleCheck, CirclePlus, CirclePlusFilled, Plus} from "@element-plus/icons-vue";
-const persistentStore = new Store('flight-core-settings.json');
+import {Notification} from '../plugins/modules/notifications';
 
 export default defineComponent({
     name: 'NotificationButton',
-    data: () => ({
-
-    }),
-    methods: {
-        CircleCheck() {
-            return CircleCheck
-        },
-        Check() {
-            return Check
-        },
-        CirclePlus() {
-            return CirclePlus
-        },
-        CirclePlusFilled() {
-            return CirclePlusFilled
-        },
-        Plus() {
-            return Plus
+    computed: {
+        notifications(): Notification[] {
+            return this.$store.state.notifications.notifications;
         }
-
-    }
+    },
 })
 </script>
 

--- a/src-vue/src/components/NotificationButton.vue
+++ b/src-vue/src/components/NotificationButton.vue
@@ -1,0 +1,25 @@
+<template>
+    <el-button color="white" icon="BellFilled" circle />
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { Store } from 'tauri-plugin-store-api';
+const persistentStore = new Store('flight-core-settings.json');
+
+export default defineComponent({
+    name: 'NotificationButton',
+    data: () => ({
+
+    }),
+    methods: {
+
+    }
+})
+</script>
+
+<style scoped>
+.el-button {
+    margin-right: 25px !important;
+}
+</style>

--- a/src-vue/src/components/NotificationButton.vue
+++ b/src-vue/src/components/NotificationButton.vue
@@ -1,6 +1,9 @@
 <template>
     <el-dropdown trigger="click" placement="bottom-end" max-height="280" popper-class="fc_popper">
-        <el-button color="white" icon="BellFilled" circle />
+        <el-badge v-if="notifications.length != 0" :value="notifications.length" :max="9" class="item" type="primary">
+            <el-button color="white" icon="BellFilled" circle />
+        </el-badge>
+        <el-button v-else color="white" icon="BellFilled" circle />
         <template #dropdown>
             <el-dropdown-menu>
                 <el-alert

--- a/src-vue/src/components/NotificationButton.vue
+++ b/src-vue/src/components/NotificationButton.vue
@@ -5,16 +5,17 @@
         </el-badge>
         <el-button v-else color="white" icon="BellFilled" circle />
         <template #dropdown>
-            <el-dropdown-menu>
+            <el-dropdown-menu :key="counter">
                 <el-alert
                     v-if="notifications.length != 0"
-                    v-for="notification in notifications"
-                    :key="JSON.stringify(notification)"
+                    v-for="(notification, i) in notifications"
+                    :key="i"
                     :title="notification.title"
                     :description="notification.text"
                     :type="notification.type"
                     show-icon
                     style="width: 300px"
+                    @close.stop="removeNotification(i)"
                 />
                 <el-result
                     v-else
@@ -36,11 +37,23 @@ import {Notification} from '../plugins/modules/notifications';
 
 export default defineComponent({
     name: 'NotificationButton',
+    data: () => ({
+        // This variable is used as a key for the dropdown menu, so we can force it to refresh when a item is deleted.
+        counter: 0
+    }),
     computed: {
         notifications(): Notification[] {
             return this.$store.state.notifications.notifications;
         }
     },
+    methods: {
+        removeNotification(index: number) {
+            this.$store.commit('removeNotification', index);
+            // By refreshing the notifications list, we ensure the first notification get the index 0, ensuring this list
+            // is synchronized with the store list.
+            this.counter += 1;
+        }
+    }
 })
 </script>
 

--- a/src-vue/src/i18n/lang/en.json
+++ b/src-vue/src/i18n/lang/en.json
@@ -146,6 +146,11 @@
     },
 
     "notification": {
+        "no_new": {
+            "title": "Up-to-date",
+            "text": "Nothing to see here!"
+        },
+
         "game_folder": {
             "new": {
                 "title": "New game folder",

--- a/src-vue/src/i18n/lang/fr.json
+++ b/src-vue/src/i18n/lang/fr.json
@@ -127,6 +127,11 @@
         }
     },
     "notification": {
+        "no_new": {
+            "title": "Vous êtes à jour",
+            "text": "Rien à voir par ici !"
+        },
+
         "game_folder": {
             "new": {
                 "title": "Nouveau dossier",

--- a/src-vue/src/plugins/modules/notifications.ts
+++ b/src-vue/src/plugins/modules/notifications.ts
@@ -18,6 +18,9 @@ export const notificationsModule = {
     mutations: {
         addNotification(state: NotificationsStoreState, payload: Notification) {
             state.notifications.push(payload);
+        },
+        removeNotification(state: NotificationsStoreState, index: number): void {
+            state.notifications.splice(index, 1);
         }
     }
   }

--- a/src-vue/src/plugins/modules/notifications.ts
+++ b/src-vue/src/plugins/modules/notifications.ts
@@ -1,0 +1,23 @@
+type NotificationType = 'success' | 'warning' | 'info' | 'error';
+
+export interface Notification {
+    title: string;
+    text: string;
+    type: NotificationType;
+}
+
+interface NotificationsStoreState {
+    notifications: Notification[];
+}
+
+
+export const notificationsModule = {
+    state: () => ({
+        notifications: []
+    }) as NotificationsStoreState,
+    mutations: {
+        push(state: NotificationsStoreState, payload: Notification) {
+            state.notifications.push(payload);
+        }
+    }
+  }

--- a/src-vue/src/plugins/modules/notifications.ts
+++ b/src-vue/src/plugins/modules/notifications.ts
@@ -16,7 +16,7 @@ export const notificationsModule = {
         notifications: []
     }) as NotificationsStoreState,
     mutations: {
-        push(state: NotificationsStoreState, payload: Notification) {
+        addNotification(state: NotificationsStoreState, payload: Notification) {
             state.notifications.push(payload);
         }
     }

--- a/src-vue/src/plugins/modules/notifications.ts
+++ b/src-vue/src/plugins/modules/notifications.ts
@@ -11,6 +11,11 @@ interface NotificationsStoreState {
 }
 
 
+/**
+ * This notification module is meant to host the list of notifications that have been fired while the application was
+ * not focused.
+ * This list is then used by the [NotificationButton] component to display notifications to user.
+ **/
 export const notificationsModule = {
     state: () => ({
         notifications: []

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -19,6 +19,7 @@ import { searchModule } from './modules/search';
 import { i18n } from '../main';
 import { pullRequestModule } from './modules/pull_requests';
 import { showErrorNotification, showNotification } from '../utils/ui';
+import { notificationsModule } from './modules/notifications';
 
 const persistentStore = new Store('flight-core-settings.json');
 
@@ -57,6 +58,7 @@ export const store = createStore<FlightCoreStore>({
     modules: {
         search: searchModule,
         pullrequests: pullRequestModule,
+        notifications: notificationsModule
     },
     state(): FlightCoreStore {
         return {

--- a/src-vue/src/style.css
+++ b/src-vue/src/style.css
@@ -50,6 +50,9 @@ body {
 .el-popper {
     width: 200px !important;
 }
+.fc_popper {
+    width: auto !important;
+}
 
 .el-popconfirm {
     word-break: break-word;

--- a/src-vue/src/utils/ui.ts
+++ b/src-vue/src/utils/ui.ts
@@ -1,5 +1,6 @@
 import { ElNotification, NotificationHandle } from "element-plus";
 import { i18n } from "../main";
+import { store } from "../plugins/store";
 
 /**
  * Displays content to the user in the form of a notification appearing on screen bottom right.
@@ -10,6 +11,7 @@ function showNotification(
     type: 'success' | 'warning' | 'error' | 'info' = 'success',
     duration: number = 4500
 ): NotificationHandle {
+    store.commit('addNotification', {title, text: message, type});
     return ElNotification({
         title, message, type, duration,
         position: 'bottom-right',

--- a/src-vue/src/utils/ui.ts
+++ b/src-vue/src/utils/ui.ts
@@ -4,6 +4,7 @@ import { store } from "../plugins/store";
 
 /**
  * Displays content to the user in the form of a notification appearing on screen bottom right.
+ * If the app is not focused when this is invoked, a notification is added to the notifications menu.
  **/
 function showNotification(
     title: string,
@@ -11,7 +12,10 @@ function showNotification(
     type: 'success' | 'warning' | 'error' | 'info' = 'success',
     duration: number = 4500
 ): NotificationHandle {
-    store.commit('addNotification', {title, text: message, type});
+    if (!document.hasFocus()) {
+        store.commit('addNotification', {title, text: message, type});
+    }
+
     return ElNotification({
         title, message, type, duration,
         position: 'bottom-right',


### PR DESCRIPTION
This PR introduces a notification menu, which hosts notifications fired while the app was not focused.
Notifications can be closed by the user.

Closes #400.

##### Screenshots

![image](https://github.com/R2NorthstarTools/FlightCore/assets/11993538/7b0a63e8-8561-419a-b531-0815006aba39)

![image](https://github.com/R2NorthstarTools/FlightCore/assets/11993538/383034bf-01e9-4bb8-a46f-1c19c9495160)

