### PR TITLE
refactor: Remove maximize window button

### DIFF
--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -34,9 +34,6 @@ export default {
     this.$root!.$i18n.locale = lang;
   },
   methods: {
-    async toggleMaximize() {
-      await appWindow.toggleMaximize();
-    },
     minimize() {
       appWindow.minimize()
     },
@@ -77,7 +74,6 @@ export default {
       <!-- Window controls -->
       <div id="fc_window__controls">
         <el-button color="white" icon="SemiSelect" @click="minimize" circle />
-        <el-button color="white" icon="FullScreen" @click="toggleMaximize" circle />
         <el-button color="white" icon="CloseBold" @click="close" circle />
       </div>
     </nav>


### PR DESCRIPTION
Spliced out from #615 
The button was removed to make space for the notification icon.

The window can still be maximised by double-clicking the top bar, dragging the window to the top of the screen, or by using keyboard shortcuts.