### PR TITLE
refactor: Move `convert_release_candidate_number`

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -193,15 +193,6 @@ fn main() {
     };
 }
 
-/// Helps with converting release candidate numbers which are different on Thunderstore
-/// due to restrictions imposed by the platform
-pub fn convert_release_candidate_number(version_number: String) -> String {
-    // This simply converts `-rc` to `0`
-    // Works as intended for RCs < 10, e.g.  `v1.9.2-rc1`  -> `v1.9.201`
-    // Doesn't work for larger numbers, e.g. `v1.9.2-rc11` -> `v1.9.2011` (should be `v1.9.211`)
-    version_number.replace("-rc", "0").replace("00", "")
-}
-
 /// Defines how Titanfall2 was installed (Steam, Origin, ...)
 #[derive(Serialize, Deserialize, Debug, Clone, TS)]
 #[ts(export)]

--- a/src-tauri/src/northstar/mod.rs
+++ b/src-tauri/src/northstar/mod.rs
@@ -91,7 +91,7 @@ pub async fn check_is_northstar_outdated(
     };
 
     // Release candidate version numbers are different between `mods.json` and Thunderstore
-    let version_number = crate::convert_release_candidate_number(version_number);
+    let version_number = crate::util::convert_release_candidate_number(version_number);
 
     if version_number != nmod.latest {
         log::info!("Installed Northstar version outdated");

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -225,3 +225,12 @@ pub fn move_dir_all(
     }
     Ok(())
 }
+
+/// Helps with converting release candidate numbers which are different on Thunderstore
+/// due to restrictions imposed by the platform
+pub fn convert_release_candidate_number(version_number: String) -> String {
+    // This simply converts `-rc` to `0`
+    // Works as intended for RCs < 10, e.g.  `v1.9.2-rc1`  -> `v1.9.201`
+    // Doesn't work for larger numbers, e.g. `v1.9.2-rc11` -> `v1.9.2011` (should be `v1.9.211`)
+    version_number.replace("-rc", "0").replace("00", "")
+}


### PR DESCRIPTION
Move `convert_release_candidate_number` to `util` module to clean up `main.rs`