### PR TITLE
fix: Address broken rc number conversion

### DIFF
--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -232,5 +232,5 @@ pub fn convert_release_candidate_number(version_number: String) -> String {
     // This simply converts `-rc` to `0`
     // Works as intended for RCs < 10, e.g.  `v1.9.2-rc1`  -> `v1.9.201`
     // Doesn't work for larger numbers, e.g. `v1.9.2-rc11` -> `v1.9.2011` (should be `v1.9.211`)
-    version_number.replace("-rc", "0").replace("00", "")
+    version_number.replace("-rc", "0").replace(".00", ".")
 }


### PR DESCRIPTION
Address broken release-candidate number conversion for double digit patch releases

`v1.19.10-rc1` would get converted to `v1.19.11` instead of `v1.19.1001`.

Tested with #652 