### PR TITLE
test: Add test for conversion of non-rc numbers

### DIFF
--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -240,6 +240,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_not_release_candidate() {
+        let input = "v1.2.3".to_string();
+        let output = convert_release_candidate_number(input.clone());
+        let expected_output = input;
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
     fn test_basic_release_candidate_number_conversion() {
         let input = "v1.2.3-rc4".to_string();
         let output = convert_release_candidate_number(input);


### PR DESCRIPTION
Non-release-candidate numbers are also put through the function and should be returned unchanged.