### PR TITLE
test: Remove the leading `v` from version numbers

### DIFF
--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -241,7 +241,7 @@ mod tests {
 
     #[test]
     fn test_not_release_candidate() {
-        let input = "v1.2.3".to_string();
+        let input = "1.2.3".to_string();
         let output = convert_release_candidate_number(input.clone());
         let expected_output = input;
         assert_eq!(output, expected_output);
@@ -249,17 +249,17 @@ mod tests {
 
     #[test]
     fn test_basic_release_candidate_number_conversion() {
-        let input = "v1.2.3-rc4".to_string();
+        let input = "1.2.3-rc4".to_string();
         let output = convert_release_candidate_number(input);
-        let expected_output = "v1.2.304";
+        let expected_output = "1.2.304";
         assert_eq!(output, expected_output);
     }
 
     #[test]
     fn test_leading_zero_release_candidate_number_conversion() {
-        let input = "v1.2.0-rc3".to_string();
+        let input = "1.2.0-rc3".to_string();
         let output = convert_release_candidate_number(input);
-        let expected_output = "v1.2.3";
+        let expected_output = "1.2.3";
         assert_eq!(output, expected_output);
     }
 
@@ -268,9 +268,9 @@ mod tests {
         // let input = "v1.2.34-rc5".to_string();
         // let output = convert_release_candidate_number(input);
         // let expected_output = "v1.2.3405";
-        let input = "v1.19.10-rc1".to_string();
+        let input = "1.19.10-rc1".to_string();
         let output = convert_release_candidate_number(input);
-        let expected_output = "v1.19.1001";
+        let expected_output = "1.19.1001";
 
         assert_eq!(output, expected_output);
     }


### PR DESCRIPTION
They don't appear in the actual version numbers either.

```json5
{
  "Name": "Northstar.Client",
  "Description": "Various ui and client changes to fix bugs and add better support for mods",
  "Version": "1.20.0", // <--- no leading `v`
  "LoadPriority": 0,
  "InitScript": "cl_northstar_client_init.nut",
  "ConVars": [
  // ...
  ]
// ...
}
```