### PR TITLE
feat: Add `ci:` as a valid tag in release note generator

### DIFF
--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -163,6 +163,7 @@ fn generate_flightcore_release_notes(commits: Vec<String>) -> String {
                     "style" => "**Code style changes:**",
                     "refactor" => "**Code Refactoring:**",
                     "build" => "**Build:**",
+                    "ci" => "**Continuous integration changes:**",
                     "test" => "**Tests:**",
                     "chore" => "**Chores:**",
                     "i18n" => "**Translations:**",


### PR DESCRIPTION
Turns `ci:` into `Continuous integration changes:`.

I added it as it's one of the suggested tags in https://www.conventionalcommits.org/en/v1.0.0/