### PR TITLE
ci: Add Action to add label to PR on merge conflict

### DIFF
--- a/.github/workflows/merge-conflict-auto-label.yml
+++ b/.github/workflows/merge-conflict-auto-label.yml
@@ -1,0 +1,16 @@
+name: Merge Conflict Auto Label
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "merge conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_RETRIES: 5
+          WAIT_MS: 5000


### PR DESCRIPTION
Adds a GitHub Action that auto-adds a label to a PR in case there are merge conflicts.

Tested successfully via https://github.com/R2Northstar/NorthstarLauncher/pull/621