### PR TITLE
fix: Add missing release note generation section entry

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -30,8 +30,8 @@ pub const BLACKLISTED_MODS: [&str; 3] = [
 pub const TITANFALL2_STEAM_ID: &str = "1237970";
 
 /// Order in which the sections for release notes should be displayed
-pub const SECTION_ORDER: [&str; 10] = [
-    "feat", "fix", "docs", "style", "refactor", "build", "test", "i18n", "chore", "other",
+pub const SECTION_ORDER: [&str; 11] = [
+    "feat", "fix", "docs", "style", "refactor", "build", "test", "i18n", "ci", "chore", "other",
 ];
 
 /// GitHub API endpoints for launcher/mods PRs


### PR DESCRIPTION
Forgot to add the new `ci` tag in previous PR