### PR TITLE
feat: Notification improvements

### DIFF
--- a/src-vue/src/i18n/lang/en.json
+++ b/src-vue/src/i18n/lang/en.json
@@ -147,7 +147,6 @@
 
     "notification": {
         "date_prefix": "at",
-
         "no_new": {
             "title": "Up-to-date",
             "text": "Nothing to see here!"

--- a/src-vue/src/i18n/lang/en.json
+++ b/src-vue/src/i18n/lang/en.json
@@ -146,6 +146,8 @@
     },
 
     "notification": {
+        "date_prefix": "at",
+
         "no_new": {
             "title": "Up-to-date",
             "text": "Nothing to see here!"

--- a/src-vue/src/i18n/lang/fr.json
+++ b/src-vue/src/i18n/lang/fr.json
@@ -131,6 +131,7 @@
         }
     },
     "notification": {
+        "date_prefix": "à",
         "no_new": {
             "title": "Vous êtes à jour",
             "text": "Rien à voir par ici !"

--- a/src-vue/src/utils/ui.ts
+++ b/src-vue/src/utils/ui.ts
@@ -1,6 +1,7 @@
-import { ElNotification, NotificationHandle } from "element-plus";
-import { i18n } from "../main";
-import { store } from "../plugins/store";
+import {ElNotification, NotificationHandle} from "element-plus";
+import {appWindow, UserAttentionType} from '@tauri-apps/api/window';
+import {i18n} from "../main";
+import {store} from "../plugins/store";
 
 /**
  * Displays content to the user in the form of a notification appearing on screen bottom right.
@@ -14,6 +15,7 @@ function showNotification(
 ): NotificationHandle {
     if (!document.hasFocus()) {
         store.commit('addNotification', {title, text: message, type});
+        appWindow.requestUserAttention(UserAttentionType.Informational);
     }
 
     return ElNotification({

--- a/src-vue/src/utils/ui.ts
+++ b/src-vue/src/utils/ui.ts
@@ -1,7 +1,7 @@
-import {ElNotification, NotificationHandle} from "element-plus";
-import {appWindow, UserAttentionType} from '@tauri-apps/api/window';
-import {i18n} from "../main";
-import {store} from "../plugins/store";
+import { ElNotification, NotificationHandle } from "element-plus";
+import { appWindow, UserAttentionType } from '@tauri-apps/api/window';
+import { i18n } from "../main";
+import { store } from "../plugins/store";
 
 /**
  * Displays content to the user in the form of a notification appearing on screen bottom right.

--- a/src-vue/src/utils/ui.ts
+++ b/src-vue/src/utils/ui.ts
@@ -14,7 +14,9 @@ function showNotification(
     duration: number = 4500
 ): NotificationHandle {
     if (!document.hasFocus()) {
-        store.commit('addNotification', {title, text: message, type});
+        const date = new Date();
+        const titleWithDate = `${title} (${i18n.global.tc('notification.date_prefix')} ${('0' + date.getHours()).slice(-2)}:${('0' + date.getMinutes()).slice(-2)})`;
+        store.commit('addNotification', {title: titleWithDate, text: message, type});
         appWindow.requestUserAttention(UserAttentionType.Informational);
     }
 


### PR DESCRIPTION
This PR introduces two notification-related changes (only applicable when application is not focused):

- display time of day in menu notifications;
- make app icon blink (on Windows at least) when a notification is fired.

Closes #634
Closes #702 

##### Screenshots

![image](https://github.com/R2NorthstarTools/FlightCore/assets/11993538/cd9c09ba-0180-45fa-b28b-d74e81eb4a4c)

![image](https://github.com/R2NorthstarTools/FlightCore/assets/11993538/571f8892-9c5c-44de-8317-79297db04394)

![image](https://github.com/R2NorthstarTools/FlightCore/assets/11993538/1d564aff-a4c0-4070-876c-da82493819dc)

