### PR TITLE
refactor: Make launching via Steam an arg passed to backend

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -137,7 +137,6 @@ fn main() {
             northstar::install::find_game_install_location,
             northstar::install::install_northstar_wrapper,
             northstar::install::update_northstar,
-            northstar::launch_northstar_steam,
             northstar::launch_northstar,
             northstar::profile::delete_profile,
             northstar::profile::fetch_profiles,

--- a/src-tauri/src/northstar/mod.rs
+++ b/src-tauri/src/northstar/mod.rs
@@ -154,9 +154,15 @@ pub fn get_northstar_version_number(game_install: GameInstall) -> Result<String,
 #[tauri::command]
 pub fn launch_northstar(
     game_install: GameInstall,
+    launch_via_steam: Option<bool>,
     bypass_checks: Option<bool>,
 ) -> Result<String, String> {
     dbg!(game_install.clone());
+
+    let launch_via_steam = launch_via_steam.unwrap_or(false);
+    if launch_via_steam {
+        return launch_northstar_steam(game_install, bypass_checks);
+    }
 
     let host_os = get_host_os();
 
@@ -222,7 +228,6 @@ pub fn launch_northstar(
 }
 
 /// Prepare Northstar and Launch through Steam using the Browser Protocol
-#[tauri::command]
 pub fn launch_northstar_steam(
     game_install: GameInstall,
     _bypass_checks: Option<bool>,

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -241,7 +241,7 @@ export const store = createStore<FlightCoreStore>({
             }
         },
         async launchGameSteam(state: any, no_checks = false) {
-            await invoke("launch_northstar_steam", { gameInstall: state.game_install, bypassChecks: no_checks })
+            await invoke("launch_northstar", { gameInstall: state.game_install, launchViaSteam: true, bypassChecks: no_checks })
                 .then((message) => {
                     showNotification('Success');
                 })


### PR DESCRIPTION
Make launching via Steam an arg passed to backend instead of a separate dedicated function.

Part of #752 