### PR TITLE
chore: Bump checkout action to v4

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -6,7 +6,7 @@ jobs:
   ensure-same-version:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: |
           pip install toml
@@ -19,7 +19,7 @@ jobs:
     name: format-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -36,7 +36,7 @@ jobs:
     name: clippy-check
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -59,7 +59,7 @@ jobs:
   autogen-ts-bindings-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -96,7 +96,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: setup node
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   ensure-same-version:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: |
           pip install toml
@@ -29,7 +29,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: setup node
       uses: actions/setup-node@v3
       with:
@@ -89,7 +89,7 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v3
     - name: Create release file
       run: |


### PR DESCRIPTION
v3 uses Node 16 which is slated for deprecation by GitHub Actions

![image](https://github.com/R2NorthstarTools/FlightCore/assets/40122905/e2da2667-f572-4bbe-9dc5-cd02fcd13eb7)
