### PR TITLE
chore: Bump upload-artifact action to v4

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -132,21 +132,21 @@ jobs:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
     - name: Upload Linux artifact
       if: matrix.platform == 'ubuntu-22.04'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-artifacts
         path: |
           src-tauri/target/release/bundle/appimage/*
     - name: Upload Linux AppImage
       if: matrix.platform == 'ubuntu-22.04'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-appimage
         path: |
           src-tauri/target/release/bundle/appimage/*.AppImage
     - name: Upload Windows artifact
       if: matrix.platform == 'windows-latest'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: windows-artifacts
         path: |
@@ -154,7 +154,7 @@ jobs:
           src-tauri/target/release/app.pdb
     - name: Additionally upload Windows installer separately
       if: matrix.platform == 'windows-latest'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: windows-msi
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
     - name: upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: |
           src-tauri/target/release/bundle/appimage/*AppImage*


### PR DESCRIPTION
v3 uses Node 16 which is slated for deprecation by GitHub Actions