### PR TITLE
refactor: Get Steam ID from libthermite

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -26,9 +26,6 @@ pub const BLACKLISTED_MODS: [&str; 3] = [
     "ebkr-r2modman",
 ];
 
-/// Titanfall2 Steam App ID
-pub const TITANFALL2_STEAM_ID: &str = "1237970";
-
 /// Order in which the sections for release notes should be displayed
 pub const SECTION_ORDER: [&str; 11] = [
     "feat", "fix", "docs", "style", "refactor", "build", "test", "i18n", "ci", "chore", "other",

--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use std::{cell::RefCell, time::Instant};
 use ts_rs::TS;
 
-use crate::constants::{CORE_MODS, NORTHSTAR_DEFAULT_PROFILE, NORTHSTAR_DLL, TITANFALL2_STEAM_ID};
+use crate::constants::{CORE_MODS, NORTHSTAR_DEFAULT_PROFILE, NORTHSTAR_DLL};
 use crate::{
     util::{extract, move_dir_all},
     GameInstall, InstallType,
@@ -310,8 +310,7 @@ pub fn find_game_install_location() -> Result<GameInstall, String> {
                 }
             }
 
-            let titanfall2_steamid = TITANFALL2_STEAM_ID.parse().unwrap();
-            match steamdir.app(&titanfall2_steamid) {
+            match steamdir.app(&thermite::TITANFALL2_STEAM_ID) {
                 Some(app) => {
                     // println!("{:#?}", app);
                     let game_install = GameInstall {

--- a/src-tauri/src/northstar/mod.rs
+++ b/src-tauri/src/northstar/mod.rs
@@ -258,7 +258,8 @@ pub fn launch_northstar_steam(
 
     match open::that(format!(
         "steam://run/{}//-profile={} --northstar/",
-        thermite::TITANFALL2_STEAM_ID, game_install.profile
+        thermite::TITANFALL2_STEAM_ID,
+        game_install.profile
     )) {
         Ok(()) => Ok("Started game".to_string()),
         Err(_err) => Err("Failed to launch Titanfall 2 via Steam".to_string()),

--- a/src-tauri/src/northstar/mod.rs
+++ b/src-tauri/src/northstar/mod.rs
@@ -4,11 +4,7 @@ pub mod install;
 pub mod profile;
 
 use crate::util::check_ea_app_or_origin_running;
-use crate::{
-    constants::{CORE_MODS, TITANFALL2_STEAM_ID},
-    platform_specific::get_host_os,
-    GameInstall, InstallType,
-};
+use crate::{constants::CORE_MODS, platform_specific::get_host_os, GameInstall, InstallType};
 use crate::{NorthstarThunderstoreRelease, NorthstarThunderstoreReleaseWrapper};
 use anyhow::anyhow;
 
@@ -239,8 +235,7 @@ pub fn launch_northstar_steam(
     match steamlocate::SteamDir::locate() {
         Some(mut steamdir) => {
             if get_host_os() != "windows" {
-                let titanfall2_steamid: u32 = TITANFALL2_STEAM_ID.parse().unwrap();
-                match steamdir.compat_tool(&titanfall2_steamid) {
+                match steamdir.compat_tool(&thermite::TITANFALL2_STEAM_ID) {
                     Some(_) => {}
                     None => {
                         return Err(
@@ -263,7 +258,7 @@ pub fn launch_northstar_steam(
 
     match open::that(format!(
         "steam://run/{}//-profile={} --northstar/",
-        TITANFALL2_STEAM_ID, game_install.profile
+        thermite::TITANFALL2_STEAM_ID, game_install.profile
     )) {
         Ok(()) => Ok("Started game".to_string()),
         Err(_err) => Err("Failed to launch Titanfall 2 via Steam".to_string()),


### PR DESCRIPTION
Instead of defining our own const, let's just re-use the one recently added to [`libthermite`](https://crates.io/crates/libthermite).