### PR TITLE
fix: Resolve clippy warning

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
         },
     ));
 
-    match tauri::Builder::default()
+    let tauri_builder_res = tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::default().build())
         .setup(|app| {
             let app_handle = app.app_handle();
@@ -161,8 +161,9 @@ fn main() {
             util::kill_northstar,
             util::open_repair_window,
         ])
-        .run(tauri::generate_context!())
-    {
+        .run(tauri::generate_context!());
+
+    match tauri_builder_res {
         Ok(()) => (),
         Err(err) => {
             // Failed to launch system native web view


### PR DESCRIPTION
Resolve clippy warning regarding too deeply nested code blocks

```
error: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
   --> src/main.rs:70:22
    |
70  |           .setup(|app| {
    |  ______________________^
71  | |             let app_handle = app.app_handle();
72  | |             tauri::async_runtime::spawn(async move {
73  | |                 loop {
...   |
115 | |             Ok(())
116 | |         })
    | |_________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_conditions
    = note: `-D clippy::blocks-in-conditions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::blocks_in_conditions)]
```