### PR TITLE
fix: Remove most leftover dbg prints

### DIFF
--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -190,7 +190,6 @@ pub async fn get_launcher_download_link(commit_sha: String) -> Result<String, St
                 for artifact in artifacts_response.artifacts {
                     // Make sure artifact and CI run commit head sha match
                     if artifact.workflow_run.head_sha == workflow_run.head_sha {
-                        dbg!(artifact.id);
 
                         // Download artifact
                         return Ok(format!("https://nightly.link/R2Northstar/NorthstarLauncher/actions/artifacts/{}.zip", artifact.id));

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -414,7 +414,6 @@ async fn get_ns_mod_download_url(thunderstore_mod_string: &str) -> Result<String
         // Iterate over all versions of a given mod
         for ns_mod in ns_mod.versions.values() {
             if ns_mod.url.contains(&ts_mod_string_url) {
-                dbg!(ns_mod.clone());
                 return Ok(ns_mod.url.clone());
             }
         }
@@ -437,7 +436,6 @@ async fn get_mod_dependencies(thunderstore_mod_string: &str) -> Result<Vec<Strin
         // Iterate over all versions of a given mod
         for ns_mod in ns_mod.versions.values() {
             if ns_mod.url.contains(&ts_mod_string_url) {
-                dbg!(ns_mod.clone());
                 return Ok(ns_mod.deps.clone());
             }
         }

--- a/src-tauri/src/repair_and_verify/mod.rs
+++ b/src-tauri/src/repair_and_verify/mod.rs
@@ -92,7 +92,6 @@ pub fn clean_up_download_folder(
             Ok(contents) => contents,
             Err(_) => continue,
         };
-        // dbg!(download_dir_contents);
 
         let mut count = 0;
         download_dir_contents.for_each(|_| count += 1);


### PR DESCRIPTION
Removes all but one leftover `dbg!()` prints. The remaining one is in a function that is yet to be implemented ^^