### PR TITLE
refactor: Use dedicated library for getting PR list

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -41,10 +41,10 @@ pub const FLIGHTCORE_REPO_NAME: &str = "R2NorthstarTools/FlightCore";
 pub const NORTHSTAR_RELEASE_REPO_NAME: &str = "R2Northstar/Northstar";
 
 /// NorthstarLauncher repo name on GitHub
-pub const NORTHSTAR_LAUNCHER_REPO_NAME: &str= "NorthstarLauncher";
+pub const NORTHSTAR_LAUNCHER_REPO_NAME: &str = "NorthstarLauncher";
 
 /// NorthstarMods repo name on GitHub
-pub const NORTHSTAR_MODS_REPO_NAME: &str= "NorthstarMods";
+pub const NORTHSTAR_MODS_REPO_NAME: &str = "NorthstarMods";
 
 /// URL to launcher commits API URL
 pub const NS_LAUNCHER_COMMITS_API_URL: &str =

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -31,12 +31,6 @@ pub const SECTION_ORDER: [&str; 11] = [
     "feat", "fix", "docs", "style", "refactor", "build", "test", "i18n", "ci", "chore", "other",
 ];
 
-/// GitHub API endpoints for launcher/mods PRs
-pub const PULLS_API_ENDPOINT_LAUNCHER: &str =
-    "https://api.github.com/repos/R2Northstar/NorthstarLauncher/pulls";
-pub const PULLS_API_ENDPOINT_MODS: &str =
-    "https://api.github.com/repos/R2Northstar/NorthstarMods/pulls";
-
 /// Statistics (players and servers counts) refresh delay
 pub const REFRESH_DELAY: Duration = Duration::from_secs(5 * 60);
 

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -40,6 +40,12 @@ pub const FLIGHTCORE_REPO_NAME: &str = "R2NorthstarTools/FlightCore";
 /// Northstar release repo name and org name on GitHub
 pub const NORTHSTAR_RELEASE_REPO_NAME: &str = "R2Northstar/Northstar";
 
+/// NorthstarLauncher repo name on GitHub
+pub const NORTHSTAR_LAUNCHER_REPO_NAME: &str= "NorthstarLauncher";
+
+/// NorthstarMods repo name on GitHub
+pub const NORTHSTAR_MODS_REPO_NAME: &str= "NorthstarMods";
+
 /// URL to launcher commits API URL
 pub const NS_LAUNCHER_COMMITS_API_URL: &str =
     "https://api.github.com/repos/R2Northstar/NorthstarLauncher/commits";

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -103,7 +103,7 @@ pub async fn get_pull_requests(
 
         // TODO there's probably a way to automatically serialize into the struct but I don't know yet how to
         let elem = PullsApiResponseElement {
-            number: item.number as i64, // bad but we never go this high anyway
+            number: item.number,
             title: item.title.ok_or(anyhow!("title not found"))?,
             url: item.url,
             head,

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -63,12 +63,11 @@ pub enum PullRequestType {
     Launcher,
 }
 
-/// Gets either launcher or mods PRs
-#[tauri::command]
-pub async fn get_pull_requests_wrapper(
-    install_type: PullRequestType,
+/// Parse pull requests from specified URL
+pub async fn get_pull_requests(
+    repo: PullRequestType,
 ) -> Result<Vec<PullsApiResponseElement>, String> {
-    let repo = match install_type {
+    let repo = match repo {
         PullRequestType::Mods => NORTHSTAR_MODS_REPO_NAME,
         PullRequestType::Launcher => NORTHSTAR_LAUNCHER_REPO_NAME,
     };
@@ -109,6 +108,14 @@ pub async fn get_pull_requests_wrapper(
     }
 
     Ok(all_pull_requests)
+}
+
+/// Gets either launcher or mods PRs
+#[tauri::command]
+pub async fn get_pull_requests_wrapper(
+    install_type: PullRequestType,
+) -> Result<Vec<PullsApiResponseElement>, String> {
+    get_pull_requests(install_type).await
 }
 
 pub async fn check_github_api(url: &str) -> Result<serde_json::Value, Box<dyn std::error::Error>> {

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -1,4 +1,4 @@
-use crate::constants::APP_USER_AGENT;
+use crate::constants::{APP_USER_AGENT, NORTHSTAR_LAUNCHER_REPO_NAME, NORTHSTAR_MODS_REPO_NAME};
 use crate::repair_and_verify::check_is_valid_game_path;
 use crate::GameInstall;
 use anyhow::anyhow;
@@ -69,8 +69,8 @@ pub async fn get_pull_requests_wrapper(
     install_type: PullRequestType,
 ) -> Result<Vec<PullsApiResponseElement>, String> {
     let repo = match install_type {
-        PullRequestType::Mods => "NorthstarMods",
-        PullRequestType::Launcher => "NorthstarLauncher",
+        PullRequestType::Mods => NORTHSTAR_MODS_REPO_NAME,
+        PullRequestType::Launcher => NORTHSTAR_LAUNCHER_REPO_NAME,
     };
 
     let octocrab = octocrab::instance();

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -72,17 +72,18 @@ pub async fn get_pull_requests(
         PullRequestType::Launcher => NORTHSTAR_LAUNCHER_REPO_NAME,
     };
 
+    // Grab list of PRs
     let octocrab = octocrab::instance();
-
     let page = octocrab
         .pulls("R2Northstar", repo)
         .list()
         .state(octocrab::params::State::Open)
-        .per_page(50)
+        .per_page(50) // Only grab 50 PRs
         .page(1u32)
         .send()
         .await?;
 
+    // Iterate over pull request elements and insert into struct
     let mut all_pull_requests: Vec<PullsApiResponseElement> = vec![];
     for item in page.items {
         let repo = Repo {
@@ -100,6 +101,7 @@ pub async fn get_pull_requests(
             repo,
         };
 
+        // TODO there's probably a way to automatically serialize into the struct but I don't know yet how to
         let elem = PullsApiResponseElement {
             number: item.number as i64, // bad but we never go this high anyway
             title: item.title.ok_or(anyhow!("title not found"))?,

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -94,14 +94,14 @@ pub async fn get_pull_requests_wrapper(
         let head = CommitHead {
             sha: item.head.sha,
             gh_ref: item.head.ref_field,
-            repo: repo,
+            repo,
         };
 
         let elem = PullsApiResponseElement {
             number: item.number as i64, // bad but we never go this high anyway
             title: item.title.unwrap(),
             url: item.url,
-            head: head,
+            head,
             html_url: item.html_url.unwrap().to_string(),
         };
 

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -1,6 +1,4 @@
-use crate::github::release_notes::fetch_github_releases_api;
-
-use crate::constants::{APP_USER_AGENT, PULLS_API_ENDPOINT_LAUNCHER, PULLS_API_ENDPOINT_MODS};
+use crate::constants::APP_USER_AGENT;
 use crate::repair_and_verify::check_is_valid_game_path;
 use crate::GameInstall;
 use anyhow::anyhow;
@@ -63,38 +61,6 @@ struct ArtifactsResponse {
 pub enum PullRequestType {
     Mods,
     Launcher,
-}
-
-/// Parse pull requests from specified URL
-pub async fn get_pull_requests(url: String) -> Result<Vec<PullsApiResponseElement>, String> {
-    let mut all_pull_requests: Vec<PullsApiResponseElement> = vec![];
-
-    let mut i = 1; // pagination on GitHub starts with `1`.
-    loop {
-        let paginated_url = format!("{}?page={}", url, i);
-
-        let json_response = match fetch_github_releases_api(&paginated_url).await {
-            Ok(result) => result,
-            Err(err) => return Err(format!("Failed fetching GitHub API {err}")),
-        };
-
-        let pulls_response: Vec<PullsApiResponseElement> =
-            match serde_json::from_str(&json_response) {
-                Ok(res) => res,
-                Err(err) => return Err(err.to_string()),
-            };
-
-        // Check if we still got a result
-        if pulls_response.is_empty() {
-            // Empty result means we went through all pages with content
-            break;
-        }
-
-        all_pull_requests.extend(pulls_response);
-        i += 1;
-    }
-
-    Ok(all_pull_requests)
 }
 
 /// Gets either launcher or mods PRs


### PR DESCRIPTION
Use the [`octocrab`](https://crates.io/crates/octocrab) library for interacting with GitHub for getting the list of pull requests

Part of:
- #806