### PR TITLE
refactor: Use `u64` for PR number

### DIFF
--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -29,7 +29,7 @@ struct CommitHead {
 #[derive(Serialize, Deserialize, Debug, Clone, TS)]
 #[ts(export)]
 pub struct PullsApiResponseElement {
-    number: i64,
+    number: u64,
     title: String,
     url: String,
     head: CommitHead,


### PR DESCRIPTION
Use `u64` for PR number instead of `i64` as PR numbers can never be negative.

Discovered while working on #807 