### PR TITLE
fix: Return actual error instead of unwrapping

### DIFF
--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -104,7 +104,7 @@ pub async fn get_northstar_release_notes() -> Result<Vec<ReleaseInfo>, String> {
         // Send the request
         .send()
         .await
-        .unwrap();
+        .map_err(|err| err.to_string())?;
 
     // TODO there's probably a way to automatically serialize into the struct but I don't know yet how to
     let mut release_info_vector: Vec<ReleaseInfo> = vec![];


### PR DESCRIPTION
Return actual error instead of `unwrap`ping so we don't crash the thread on connection error but instead return an error message.