### PR TITLE
style: Improve release note formatting

### DIFF
--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -175,15 +175,15 @@ pub async fn generate_release_note_announcement() -> Result<String, String> {
 
 {general_info}
 
-**__Modders:__**
+__**Modders:**__
 
 {modders_info}
 
-**__Server hosters:__**
+__**Server hosters:**__
 
 {server_hosters_info}
 
-**__Changelog:__**
+__**Changelog:**__
 ```
 {changelog}
 ```


### PR DESCRIPTION
Improve release note formatting by putting bold inside underline

In the source, the underscores are harder to see if all the text is already underlined