### PR TITLE
chore: bump vite from 3.2.7 to 3.2.8

### DIFF
--- a/src-vue/package-lock.json
+++ b/src-vue/package-lock.json
@@ -1188,9 +1188,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.7.tgz",
-      "integrity": "sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.8.tgz",
+      "integrity": "sha512-EtQU16PLIJpAZol2cTLttNP1mX6L0SyI0pgQB1VOoWeQnMSvtiwovV3D6NcjN8CZQWWyESD2v5NGnpz5RvgOZA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.15.9",


### PR DESCRIPTION
Apparently the current version has some security vuln according to npm. It doesn't affect us but bumping it won't hurt either.