### PR TITLE
feat: Add disable all mods button to local mod view

### DIFF
--- a/src-vue/src/views/mods/LocalModsView.vue
+++ b/src-vue/src/views/mods/LocalModsView.vue
@@ -5,7 +5,7 @@
     </div>
 
     <el-scrollbar v-else>
-        <el-button type="primary" @click="disableAllModsButCore">
+        <el-button class="disableModsBtn" type="primary" @click="disableAllModsButCore">
             {{ $t('settings.repair.window.disable_all_but_core') }}
         </el-button>
         <local-mod-card v-for="mod of mods" v-bind:key="mod.name" :mod="mod" />
@@ -64,5 +64,9 @@ export default defineComponent({
 </script>
 
 <style scoped>
-
+.disableModsBtn {
+    margin-bottom: 10px;
+    top: 10px;
+    position: sticky;
+}
 </style>

--- a/src-vue/src/views/mods/LocalModsView.vue
+++ b/src-vue/src/views/mods/LocalModsView.vue
@@ -5,14 +5,19 @@
     </div>
 
     <el-scrollbar v-else>
+        <el-button type="primary" @click="disableAllModsButCore">
+            {{ $t('settings.repair.window.disable_all_but_core') }}
+        </el-button>
         <local-mod-card v-for="mod of mods" v-bind:key="mod.name" :mod="mod" />
     </el-scrollbar>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { invoke } from "@tauri-apps/api";
 import { NorthstarMod } from "../../../../src-tauri/bindings/NorthstarMod";
 import { fuzzy_filter } from "../../utils/filter";
+import { showErrorNotification, showNotification } from "../../utils/ui";
 import LocalModCard from "../../components/LocalModCard.vue";
 
 export default defineComponent({
@@ -41,6 +46,16 @@ export default defineComponent({
         };
     },
     methods: {
+        async disableAllModsButCore() {
+            await invoke("disable_all_but_core", { gameInstall: this.$store.state.game_install })
+                .then((message) => {
+                    showNotification(this.$t('generic.success'), this.$t('settings.repair.window.disable_all_but_core_success'));
+                    this.$store.commit('loadInstalledMods');
+                })
+                .catch((error) => {
+                    showErrorNotification(error);
+                });
+        },
     },
     mounted() {
         this.$store.commit('loadInstalledMods');


### PR DESCRIPTION
Initial PoC to add a button to local mod view to directly disable all mods except core ones.

This button already exists in RepairView but given how cumbersome that is to access, having a button additionally directly in the local mods view would be nice.

For context I observed a lot of cases recently on the Northstar Discord where players would have their game break by conflicting mods and staff would tell them to try to disable individual mods one-by-one. I would argue that instead having a quick way to disable all mods and then slowly re-enabling them would be a way faster method of reducing the player's issue.

This PR adds a button to achieve just that ^^

![image](https://github.com/R2NorthstarTools/FlightCore/assets/40122905/d7a9ad4b-4d51-430f-bf47-024e7957cb53)
