### PR TITLE
chore: Update tauri-plugin-store

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4721,8 +4721,8 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-store"
-version = "0.1.0"
-source = "git+https://github.com/tauri-apps/plugins-workspace?rev=5a6abd3203dc94c38f96d0c4bf7ecbef399f8c25#5a6abd3203dc94c38f96d0c4bf7ecbef399f8c25"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#4aeee08cde4cf8253b7b52c2204655ac8bb6769d"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,7 +43,7 @@ sysinfo = "0.30.7"
 # HTTP requests
 reqwest = { version = "0.11", features = ["blocking"] }
 # Persistent store for settings
-tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", rev = "5a6abd3203dc94c38f96d0c4bf7ecbef399f8c25" }
+tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 # JSON5 parsing support (allows comments in JSON)
 json5 = "0.4.1"
 # Async recursion for recursive mod install

--- a/src-vue/package-lock.json
+++ b/src-vue/package-lock.json
@@ -11,7 +11,7 @@
         "@element-plus/icons-vue": "^2.0.9",
         "element-plus": "^2.6.0",
         "marked": "^12.0.1",
-        "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#9bd993aa67766596638bbfd91e79a1bf8f632014",
+        "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#v1",
         "vue": "^3.4.21",
         "vue-i18n": "^9.10.2",
         "vue-router": "^4.3.0",
@@ -163,11 +163,11 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-n13pIqdPd3KtaMmmAcrU7BTfdMtIlGNnfZD0dNX8L4p8dgmuNyikm6JAA+yCpl9gqq6I8x5cV2Y0muqdgD0cWw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-1.5.3.tgz",
+      "integrity": "sha512-zxnDjHHKjOsrIzZm6nO5Xapb/BxqUq1tc7cGkFXsFkGTsSWgCPH1D8mm0XS9weJY2OaR73I3k3S+b7eSzJDfqA==",
       "engines": {
-        "node": ">= 12.22.0",
+        "node": ">= 14.6.0",
         "npm": ">= 6.6.0",
         "yarn": ">= 1.19.1"
       },
@@ -1158,19 +1158,12 @@
       }
     },
     "node_modules/tauri-plugin-store-api": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/tauri-apps/tauri-plugin-store.git#9bd993aa67766596638bbfd91e79a1bf8f632014",
-      "integrity": "sha512-X0cDDcEVLY2X8qCLISgAjzuBKDn7bJkj4S7LnXbEPFbPRe+NzhmFGHSAdFCuQuPzQYjmrVg18mZx9NAg4GBHag==",
-      "license": "MIT",
+      "version": "0.0.0",
+      "resolved": "git+ssh://git@github.com/tauri-apps/tauri-plugin-store.git#02243686d0507d2aeeb2924cd889dd0bcb47ecef",
+      "license": "MIT or APACHE-2.0",
       "dependencies": {
-        "@tauri-apps/api": "1.1.0",
-        "tslib": "2.4.0"
+        "@tauri-apps/api": "1.5.3"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/typescript": {
       "version": "5.3.3",

--- a/src-vue/package.json
+++ b/src-vue/package.json
@@ -12,7 +12,7 @@
     "@element-plus/icons-vue": "^2.0.9",
     "element-plus": "^2.6.0",
     "marked": "^12.0.1",
-    "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#9bd993aa67766596638bbfd91e79a1bf8f632014",
+    "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#v1",
     "vue": "^3.4.21",
     "vue-i18n": "^9.10.2",
     "vue-router": "^4.3.0",


### PR DESCRIPTION
uses the dependency declaration recommended by upstream and lets us get rid of ugly build errors

![image](https://github.com/R2NorthstarTools/FlightCore/assets/15076013/ab33ece3-34e8-4072-8348-daa530f63d7d)
