### PR TITLE
chore: Change dependabot PR interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore: "
 
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/src-vue'
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore: "
 
@@ -22,6 +22,6 @@ updates:
   - package-ecosystem: 'cargo'
     directory: '/src-tauri'
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore: "


### PR DESCRIPTION
Daily feels a bit too much at this point given how many dependencies we have and how often some of them are updated. Weekly feels a bit more sane in that regard.