### PR TITLE
fix: Properly handle steamlocate app location tristate

### DIFF
--- a/src-tauri/src/northstar/install.rs
+++ b/src-tauri/src/northstar/install.rs
@@ -311,8 +311,7 @@ pub fn find_game_install_location() -> Result<GameInstall, String> {
             }
 
             match steamdir.find_app(thermite::TITANFALL2_STEAM_ID) {
-                Ok(result) => {
-                    let (app, library) = result.unwrap();
+                Ok(Some((app, library))) => {
                     let app_path = library
                         .path()
                         .join("steamapps")
@@ -329,7 +328,11 @@ pub fn find_game_install_location() -> Result<GameInstall, String> {
                     };
                     return Ok(game_install);
                 }
-                Err(err) => log::info!("Couldn't locate Titanfall2 Steam install. {}", err),
+                Ok(None) => log::info!("Couldn't locate your Titanfall 2 Steam install."),
+                Err(err) => log::info!(
+                    "Something went wrong while trying to find Titanfall 2 {}",
+                    err
+                ),
             }
         }
         Err(err) => log::info!("Couldn't locate Steam on this computer! {}", err),


### PR DESCRIPTION
`find_app` returns a complex a `Result<Option<t>>` which gives us the tristate of 

1. checked and its there
2. checked and its not there
3. something fucked up

we only caught 1 and 3