### PR TITLE
feat: Prevent installation of Vanilla+ mod

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -26,6 +26,9 @@ pub const BLACKLISTED_MODS: [&str; 3] = [
     "ebkr-r2modman",
 ];
 
+/// List of Thunderstoremods that have some specific install requirements that makes them different from standard mods
+pub const MODS_WITH_SPECIAL_REQUIREMENTS: [&str; 1] = ["NanohmProtogen-VanillaPlus"];
+
 /// Order in which the sections for release notes should be displayed
 pub const SECTION_ORDER: [&str; 11] = [
     "feat", "fix", "docs", "style", "refactor", "build", "test", "i18n", "ci", "chore", "other",

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -1,6 +1,6 @@
 // This file contains various mod management functions
 
-use crate::constants::{BLACKLISTED_MODS, CORE_MODS};
+use crate::constants::{BLACKLISTED_MODS, CORE_MODS, MODS_WITH_SPECIAL_REQUIREMENTS};
 use async_recursion::async_recursion;
 use thermite::prelude::ThermiteError;
 
@@ -606,6 +606,16 @@ pub async fn fc_download_mod_and_install(
     for blacklisted_mod in BLACKLISTED_MODS {
         if thunderstore_mod_string.contains(blacklisted_mod) {
             return Err("Cannot install Northstar as a mod!".to_string());
+        }
+    }
+
+    // Prevent installing mods that have specific install requirements
+    for special_mod in MODS_WITH_SPECIAL_REQUIREMENTS {
+        if thunderstore_mod_string.contains(special_mod) {
+            return Err(format!(
+                "{} has special install requirements and cannot be installed with FlightCore",
+                thunderstore_mod_string
+            ));
         }
     }
 


### PR DESCRIPTION
Prevent installation of Vanilla+ mod as it has special installation requirements that makes it not installable like common Northstar mods.