### PR TITLE
chore: Remove deprecated dev library

### DIFF
--- a/src-vue/package-lock.json
+++ b/src-vue/package-lock.json
@@ -18,7 +18,6 @@
         "vuex": "^4.0.2"
       },
       "devDependencies": {
-        "@types/marked": "^6.0.0",
         "@vitejs/plugin-vue": "^3.1.0",
         "typescript": "^5.5.4",
         "vite": "^3.1.0",
@@ -219,16 +218,6 @@
       "integrity": "sha512-euY3XQcZmIzSy7YH5+Unb3b2X12Wtk54YWINBvvGQ5SmMvwb11JQskGsfkH/5HXK77Kr8GF0wkVDIxzAisWtog==",
       "dependencies": {
         "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/marked": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-6.0.0.tgz",
-      "integrity": "sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA==",
-      "deprecated": "This is a stub types definition. marked provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "marked": "*"
       }
     },
     "node_modules/@types/web-bluetooth": {

--- a/src-vue/package.json
+++ b/src-vue/package.json
@@ -19,7 +19,6 @@
     "vuex": "^4.0.2"
   },
   "devDependencies": {
-    "@types/marked": "^6.0.0",
     "@vitejs/plugin-vue": "^3.1.0",
     "typescript": "^5.5.4",
     "vite": "^3.1.0",


### PR DESCRIPTION
marked provides its own type defintions for a while now