### PR TITLE
feat: Switch location of Mods and Changelog tabs

### DIFF
--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -13,8 +13,8 @@ import NotificationButton from "./components/NotificationButton.vue";
 export default {
   components: {
       NotificationButton,
-      DeveloperView,
       ChangelogView,
+      DeveloperView,
       PlayView,
       SettingsView,
       ModsView

--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -13,8 +13,8 @@ import NotificationButton from "./components/NotificationButton.vue";
 export default {
   components: {
       NotificationButton,
-      ChangelogView,
       DeveloperView,
+      ChangelogView,
       PlayView,
       SettingsView,
       ModsView
@@ -67,8 +67,8 @@ export default {
         data-tauri-drag-region
       >
         <el-menu-item index="/">{{ $t('menu.play') }}</el-menu-item>
-        <el-menu-item index="/changelog">{{ $t('menu.changelog') }}</el-menu-item>
         <el-menu-item index="/mods">{{ $t('menu.mods') }}</el-menu-item>
+        <el-menu-item index="/changelog">{{ $t('menu.changelog') }}</el-menu-item>
         <el-menu-item index="/settings">{{ $t('menu.settings') }}</el-menu-item>
         <el-menu-item index="/dev" v-if="$store.state.developer_mode">{{ $t('menu.dev') }}</el-menu-item>
       </el-menu>


### PR DESCRIPTION
Usually players care more about mods than changelogs so it should be further in front.

Old:
![image](https://github.com/user-attachments/assets/6b44b10b-7c37-45c2-8953-ad1411f5527f)

New:
![image](https://github.com/user-attachments/assets/060ce503-45b3-431a-9fb9-0bd9241ab5b2)
(stripes are from dev build and unrelated)
