### PR TITLE
fix: Sort contributors case insensitive

### DIFF
--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -279,7 +279,7 @@ pub fn compare_tags_northstar(first_tag: Tag, second_tag: Tag) -> Result<String,
 
     // Convert the set to a sorted vector.
     let mut sorted_vec: Vec<String> = authors_set.into_iter().collect();
-    sorted_vec.sort();
+    sorted_vec.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
 
     // Define a string to prepend to each element.
     let prefix = "@";

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -279,7 +279,7 @@ pub fn compare_tags_northstar(first_tag: Tag, second_tag: Tag) -> Result<String,
 
     // Convert the set to a sorted vector.
     let mut sorted_vec: Vec<String> = authors_set.into_iter().collect();
-    sorted_vec.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    sorted_vec.sort_by_key(|a| a.to_lowercase());
 
     // Define a string to prepend to each element.
     let prefix = "@";


### PR DESCRIPTION
Sort contributors case insensitive when generating Northstar release notes


**Before:**
![image](https://github.com/user-attachments/assets/1fd799db-d2a8-4e91-9267-e8bc72fd5db6)


**After:**
![image](https://github.com/user-attachments/assets/d4b78232-61b5-4235-a536-daf073bd4d91)
