### PR TITLE
chore: Bump vulnerable npm packages

### DIFF
--- a/src-vue/package-lock.json
+++ b/src-vue/package-lock.json
@@ -1165,10 +1165,11 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -1244,10 +1245,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.8.tgz",
-      "integrity": "sha512-EtQU16PLIJpAZol2cTLttNP1mX6L0SyI0pgQB1VOoWeQnMSvtiwovV3D6NcjN8CZQWWyESD2v5NGnpz5RvgOZA==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.11.tgz",
+      "integrity": "sha512-K/jGKL/PgbIgKCiJo5QbASQhFiV02X9Jh+Qq0AKCRCRKZtOTVi4t6wh75FDpGf2N9rYOnzH87OEFQNaFy6pdxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.15.9",
         "postcss": "^8.4.18",


### PR DESCRIPTION
```
# npm audit report

rollup  <2.79.2
Severity: high
DOM Clobbering Gadget found in rollup bundled scripts that leads to XSS - https://github.com/advisories/GHSA-gcx4-mw62-g8wm
fix available via `npm audit fix`
node_modules/rollup

vite  <=3.2.10
Severity: moderate
Vite's `server.fs.deny` did not deny requests for patterns with directories. - https://github.com/advisories/GHSA-8jhw-289h-jh2g
Vite DOM Clobbering gadget found in vite bundled scripts that leads to XSS - https://github.com/advisories/GHSA-64vr-g452-qvp3
Vite's `server.fs.deny` is bypassed when using `?import&raw` - https://github.com/advisories/GHSA-9cwx-2883-4wfx
fix available via `npm audit fix`
node_modules/vite

2 vulnerabilities (1 moderate, 1 high)
```