### PR TITLE
ci: Run CI weekly to cover Rust toolchain updates

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -1,5 +1,9 @@
 name: "test-on-push"
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 0" # Run weekly to cover rust toolchain updates
 
 jobs:
   # Ensure version numbers in various places match up


### PR DESCRIPTION
Rust toolchain updates every six weeks including clippy. With new updates clippy can cover more cases that it previously missed so with weekly CI runs we can catch these cases and fix them in a timely manner.