### PR TITLE
fix: Address clippy error regarding zombie child process

### DIFF
--- a/src-tauri/src/northstar/mod.rs
+++ b/src-tauri/src/northstar/mod.rs
@@ -214,10 +214,11 @@ pub fn launch_northstar(
         let ns_exe_path = format!("{}/NorthstarLauncher.exe", game_install.game_path);
         let ns_profile_arg = format!("-profile={}", game_install.profile);
 
-        let _output = std::process::Command::new("C:\\Windows\\System32\\cmd.exe")
+        let mut output = std::process::Command::new("C:\\Windows\\System32\\cmd.exe")
             .args(["/C", "start", "", &ns_exe_path, &ns_profile_arg])
             .spawn()
             .expect("failed to execute process");
+        output.wait().expect("failed waiting on child process");
         return Ok("Launched game".to_string());
     }
 


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#zombie_processes

```
warning: spawned process is never `wait()`ed on
   --> src/northstar/mod.rs:217:23
    |
217 |           let _output = std::process::Command::new("C:\\Windows\\System32\\cmd.exe")
    |  _______________________^
218 | |             .args(["/C", "start", "", &ns_exe_path, &ns_profile_arg])
219 | |             .spawn()
220 | |             .expect("failed to execute process");
    | |________________________________________________^
    |
    = note: consider calling `.wait()`
    = note: not doing so might leave behind zombie processes
    = note: see https://doc.rust-lang.org/stable/std/process/struct.Child.html#warning
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#zombie_processes
    = note: `#[warn(clippy::zombie_processes)]` on by default
```