### PR TITLE
fix: URLs and file explorer open using default software

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,6 +15,14 @@
     "dialog:allow-ask",
     "dialog:allow-message",
     "opener:default",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [
+        {
+          "path": "/**"
+        }
+      ]
+    },
     "store:default",
     "updater:default"
   ]

--- a/src-vue/src/components/ThunderstoreModCard.vue
+++ b/src-vue/src/components/ThunderstoreModCard.vue
@@ -69,7 +69,7 @@ import { defineComponent } from "vue";
 import { ThunderstoreMod } from "../../../src-tauri/bindings/ThunderstoreMod";
 import { ThunderstoreModVersion } from "../../../src-tauri/bindings/ThunderstoreModVersion";
 import { invoke } from "@tauri-apps/api/core";
-import { open } from '@tauri-apps/plugin-shell';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { ThunderstoreModStatus } from "../utils/thunderstore/ThunderstoreModStatus";
 import { NorthstarMod } from "../../../src-tauri/bindings/NorthstarMod";
 import { ElMessageBox } from "element-plus";
@@ -190,7 +190,7 @@ export default defineComponent({
          * This is used to open Thunderstore mod pages.
          */
         openURL(url: string): void {
-            open(url);
+            openUrl(url);
         },
 
         /**

--- a/src-vue/src/plugins/modules/pull_requests.ts
+++ b/src-vue/src/plugins/modules/pull_requests.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { open } from '@tauri-apps/plugin-shell';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { PullsApiResponseElement } from "../../../../src-tauri/bindings/PullsApiResponseElement";
 import { PullRequestType } from '../../../../src-tauri/bindings/PullRequestType';
 import { store } from "../store";
@@ -41,7 +41,7 @@ export const pullRequestModule = {
             await invoke<string>("get_launcher_download_link", { commitSha: pull_request.head.sha })
                 .then((url) => {
                     // Open URL in default HTTPS handler (i.e. default browser)
-                    open(url);
+                    openUrl(url);
                 })
                 .catch((error) => {
                     showErrorNotification(error);
@@ -49,7 +49,7 @@ export const pullRequestModule = {
         },
         async downloadModsPR(_state: PullRequestStoreState, pull_request: PullsApiResponseElement) {
             let url = `https://github.com/${pull_request.head.repo.full_name}/archive/refs/heads/${pull_request.head.ref}.zip`
-            open(url);
+            openUrl(url);
         },
         async installLauncherPR(_state: PullRequestStoreState, pull_request: PullsApiResponseElement) {
             // Send notification telling the user to wait for the process to finish

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -149,7 +149,7 @@ import { load } from '@tauri-apps/plugin-store';
 import { showErrorNotification, showNotification } from "../utils/ui";
 import LanguageSelector from "../components/LanguageSelector.vue";
 const persistentStore = await load('flight-core-settings.json', { autoSave: false });
-import { open } from '@tauri-apps/plugin-shell';
+import { openPath } from '@tauri-apps/plugin-opener';
 import { i18n } from '../main';
 import { ElMessageBox } from 'element-plus'
 
@@ -259,7 +259,7 @@ export default defineComponent({
             }
 
             // Opens the folder in default file explorer application
-            await open(`${this.$store.state.game_install.game_path}`);
+            await openPath(`${this.$store.state.game_install.game_path}`);
         },
         async switchProfile(value: string) {
             let store = this.$store;


### PR DESCRIPTION
The way of opening URLs and file explorer changed in Tauri v2, and we*may* have forgotten to check it out during the migration 😄 

Fixes #1130.